### PR TITLE
Binary sensor naming changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ comfoair:
     name: "fan_speed_supply"
   fan_speed_exhaust:
     name: "fan_speed_exhaust"
-  is_bypass_valve_open:
-    name: "is_bypass_valve_open"
-  is_preheating:
-    name: "is_preheating"
+  bypass_valve_open:
+    name: "bypass_valve_open"
+  preheating:
+    name: "preheating"
   outside_air_temperature:
     name: "outside_air_temperature"
   supply_air_temperature:
@@ -52,18 +52,18 @@ comfoair:
     name: "return_air_level"
   supply_air_level:
     name: "supply_air_level"
-  is_supply_fan_active:
-    name: "is_supply_fan_active"
-  is_filter_full:
-    name: "is_filter_full"
+  supply_fan_active:
+    name: "supply_fan_active"
+  filter_full:
+    name: "filter_full"
   bypass_factor:
     name: "bypass_factor"
   bypass_step:
     name: "bypass_step"
   bypass_correction:
     name: "bypass_correction"
-  is_summer_mode:
-    name: "is_summer_mode"
+  summer_mode:
+    name: "summer_mode"
 ```
 
 The sensor defined here is a full list of sensor - if you remove sensor from yaml it will be not monitored.

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -45,10 +45,10 @@ comfoair:
     name: "fan_speed_supply"
   fan_speed_exhaust:
     name: "fan_speed_exhaust"
-  is_bypass_valve_open:
-    name: "is_bypass_valve_open"
-  is_preheating:
-    name: "is_preheating"
+  bypass_valve_open:
+    name: "bypass_valve_open"
+  preheating:
+    name: "preheating"
   outside_air_temperature:
     name: "outside_air_temperature"
   supply_air_temperature:
@@ -69,15 +69,15 @@ comfoair:
     name: "return_air_level"
   supply_air_level:
     name: "supply_air_level"
-  is_supply_fan_active:
-    name: "is_supply_fan_active"
-  is_filter_full:
-    name: "is_filter_full"
+  supply_fan_active:
+    name: "supply_fan_active"
+  filter_full:
+    name: "filter_full"
   bypass_factor:
     name: "bypass_factor"
   bypass_step:
     name: "bypass_step"
   bypass_correction:
     name: "bypass_correction"
-  is_summer_mode:
-    name: "is_summer_mode"
+  summer_mode:
+    name: "summer_mode"

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -1,4 +1,5 @@
 """ Creates module ComfoAir """
+
 import esphome.config_validation as cv
 import esphome.codegen as cg
 from esphome.const import *
@@ -8,13 +9,14 @@ from esphome.components import sensor
 from esphome.components import binary_sensor
 from esphome.components import text_sensor
 from esphome import pins
-comfoair_ns = cg.esphome_ns.namespace('comfoair')
-ComfoAirComponent = comfoair_ns.class_('ComfoAirComponent', cg.Component)
 
-DEPENDENCIES=['uart']
-AUTO_LOAD = ['sensor', 'climate', 'binary_sensor', 'text_sensor']
+comfoair_ns = cg.esphome_ns.namespace("comfoair")
+ComfoAirComponent = comfoair_ns.class_("ComfoAirComponent", cg.Component)
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["sensor", "climate", "binary_sensor", "text_sensor"]
 REQUIRED_KEY_NAME = "name"
-CONF_HUB_ID = 'comfoair'
+CONF_HUB_ID = "comfoair"
 
 CONF_FAN_SUPPLY_AIR_PERCENTAGE = "fan_supply_air_percentage"
 CONF_FAN_EXHAUST_AIR_PERCENTAGE = "fan_exhaust_air_percentage"
@@ -66,107 +68,138 @@ helper_comfoair = {
         CONF_SUPPLY_FAN_ACTIVE,
         CONF_FILTER_FULL,
     ],
-    "text_sensor": []
+    "text_sensor": [],
 }
 
-comfoair_sensors_schemas = cv.Schema({
-cv.Optional(CONF_FAN_SUPPLY_AIR_PERCENTAGE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_SPEED,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_FAN_EXHAUST_AIR_PERCENTAGE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_SPEED,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_FAN_SPEED_SUPPLY): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_SPEED,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_FAN_SPEED_EXHAUST): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_SPEED,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_OUTSIDE_AIR_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_SUPPLY_AIR_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_RETURN_AIR_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_EXHAUST_AIR_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_ENTHALPY_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_EWT_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_REHEATING_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_KITCHEN_HOOD_TEMPERATURE): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_TEMPERATURE,
-    unit_of_measurement=UNIT_CELSIUS,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_RETURN_AIR_LEVEL): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_VOLUME,
-    unit_of_measurement=UNIT_CUBIC_METER,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_SUPPLY_AIR_LEVEL): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_VOLUME,
-    unit_of_measurement=UNIT_CUBIC_METER,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_BYPASS_FACTOR): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_VOLUME,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_BYPASS_STEP): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_VOLUME,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_BYPASS_CORRECTION): sensor.sensor_schema(
-    device_class=DEVICE_CLASS_VOLUME,
-    unit_of_measurement=UNIT_PERCENT,
-    accuracy_decimals=1,
-    state_class=STATE_CLASS_MEASUREMENT).extend(),
-cv.Optional(CONF_BYPASS_VALVE_OPEN): binary_sensor.binary_sensor_schema(device_class=DEVICE_CLASS_EMPTY).extend(),
-cv.Optional(CONF_PREHEATING): binary_sensor.binary_sensor_schema(device_class=DEVICE_CLASS_EMPTY).extend(),
-cv.Optional(CONF_SUMMER_MODE): binary_sensor.binary_sensor_schema(device_class=DEVICE_CLASS_EMPTY).extend(),
-cv.Optional(CONF_SUPPLY_FAN_ACTIVE): binary_sensor.binary_sensor_schema(device_class=DEVICE_CLASS_EMPTY).extend(),
-cv.Optional(CONF_FILTER_FULL): binary_sensor.binary_sensor_schema(device_class=DEVICE_CLASS_EMPTY).extend(),
-})
+comfoair_sensors_schemas = cv.Schema(
+    {
+        cv.Optional(CONF_FAN_SUPPLY_AIR_PERCENTAGE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_SPEED,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_FAN_EXHAUST_AIR_PERCENTAGE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_SPEED,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_FAN_SPEED_SUPPLY): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_SPEED,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_FAN_SPEED_EXHAUST): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_SPEED,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_OUTSIDE_AIR_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_SUPPLY_AIR_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_RETURN_AIR_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_EXHAUST_AIR_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_ENTHALPY_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_EWT_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_REHEATING_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_KITCHEN_HOOD_TEMPERATURE): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_RETURN_AIR_LEVEL): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_VOLUME,
+            unit_of_measurement=UNIT_CUBIC_METER,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_SUPPLY_AIR_LEVEL): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_VOLUME,
+            unit_of_measurement=UNIT_CUBIC_METER,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_BYPASS_FACTOR): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_VOLUME,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_BYPASS_STEP): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_VOLUME,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_BYPASS_CORRECTION): sensor.sensor_schema(
+            device_class=DEVICE_CLASS_VOLUME,
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ).extend(),
+        cv.Optional(CONF_BYPASS_VALVE_OPEN): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_PREHEATING): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_SUMMER_MODE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_SUPPLY_FAN_ACTIVE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_FILTER_FULL): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+    }
+)
 
 CONFIG_SCHEMA = cv.All(
-    cv.Schema( {
-        cv.GenerateID(CONF_ID): cv.declare_id(ComfoAirComponent),
-        cv.Required(REQUIRED_KEY_NAME): cv.string,
-    })
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ID): cv.declare_id(ComfoAirComponent),
+            cv.Required(REQUIRED_KEY_NAME): cv.string,
+        }
+    )
     .extend(uart.UART_DEVICE_SCHEMA)
     .extend(comfoair_sensors_schemas)
     .extend(cv.COMPONENT_SCHEMA)
@@ -181,19 +214,18 @@ def to_code(config):
     cg.add(var.set_name(config[REQUIRED_KEY_NAME]))
     paren = yield cg.get_variable(config[CONF_UART_ID])
     cg.add(var.set_uart_component(paren))
-    for k in helper_comfoair["sensor"]:
-        if k in config:
-            sens = yield sensor.new_sensor(config[k])
-            func = getattr(var, 'set_'+k)
-            cg.add(func(sens))
-    for k in helper_comfoair["binary_sensor"]:
-        if k in config:
-            sens = yield binary_sensor.new_binary_sensor(config[k])
-            func = getattr(var, 'set_'+k)
-            cg.add(func(sens))
-    for k in helper_comfoair["text_sensor"]:
-        if k in config:
-            sens = yield text_sensor.new_text_sensor(config[k])
-            func = getattr(var, 'set_'+k)
-            cg.add(func(sens))
+    for k in helper_comfoair:
+        for v in helper_comfoair[k]:
+            if not v in config:
+                continue
+            sens = None
+            if k == "sensor":
+                sens = yield sensor.new_sensor(config[v])
+            elif k == "binary_sensor":
+                sens = yield binary_sensor.new_binary_sensor(config[v])
+            elif k == "text_sensor":
+                sens = yield text_sensor.new_text_sensor(config[v])
+            if sens is not None:
+                func = getattr(var, "set_" + v)
+                cg.add(func(sens))
     cg.add(cg.App.register_climate(var))

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -321,11 +321,11 @@ protected:
           break;
         }
       case COMFOAIR_GET_VALVE_STATUS_RESPONSE: {
-        if (this->is_bypass_valve_open != nullptr) {
-          this->is_bypass_valve_open->publish_state(msg[0] != 0);
+        if (this->bypass_valve_open != nullptr) {
+          this->bypass_valve_open->publish_state(msg[0] != 0);
         }
-        if (this->is_preheating != nullptr) {
-            this->is_preheating->publish_state(msg[1] != 0);
+        if (this->preheating != nullptr) {
+            this->preheating->publish_state(msg[1] != 0);
         }
         break;
       }
@@ -339,8 +339,8 @@ protected:
         if (this->bypass_correction != nullptr) {
           this->bypass_correction->publish_state(msg[4]);
         }
-        if (this->is_summer_mode != nullptr) {
-          this->is_summer_mode->publish_state(msg[6] != 0);
+        if (this->summer_mode != nullptr) {
+          this->summer_mode->publish_state(msg[6] != 0);
         }
         break;
       }
@@ -410,14 +410,14 @@ protected:
         this->publish_state();
 
         // Supply air fan active (1 = active / 0 = inactive)
-        if (this->is_supply_fan_active != nullptr) {
-          this->is_supply_fan_active->publish_state(msg[9] == 1);
+        if (this->supply_fan_active != nullptr) {
+          this->supply_fan_active->publish_state(msg[9] == 1);
         }
         break;
       }
       case COMFOAIR_GET_ERROR_STATE_RESPONSE: {
-        if (this->is_filter_full != nullptr) {
-          this->is_filter_full->publish_state(msg[8] != 0);
+        if (this->filter_full != nullptr) {
+          this->filter_full->publish_state(msg[8] != 0);
         }
         break;
       }
@@ -473,15 +473,15 @@ protected:
   }
 
   void get_valve_status_() {
-    if (this->is_bypass_valve_open != nullptr ||
-        this->is_preheating != nullptr) {
+    if (this->bypass_valve_open != nullptr ||
+        this->preheating != nullptr) {
       ESP_LOGD(TAG, "getting valve status");
       this->write_command_(COMFOAIR_GET_VALVE_STATUS_REQUEST, nullptr, 0);
     }
   }
 
   void get_error_status_() {
-    if (this->is_filter_full != nullptr) {
+    if (this->filter_full != nullptr) {
       ESP_LOGD(TAG, "getting error status");
       this->write_command_(COMFOAIR_GET_ERROR_STATE_REQUEST, nullptr, 0);
     }
@@ -491,7 +491,7 @@ protected:
     if (this->bypass_factor != nullptr ||
       this->bypass_step != nullptr ||
       this->bypass_correction != nullptr ||
-      this->is_summer_mode != nullptr) {
+      this->summer_mode != nullptr) {
       ESP_LOGD(TAG, "getting bypass control");
       this->write_command_(COMFOAIR_GET_BYPASS_CONTROL_REQUEST, nullptr, 0);
     }
@@ -559,18 +559,18 @@ public:
   sensor::Sensor *bypass_factor{nullptr};
   sensor::Sensor *bypass_step{nullptr};
   sensor::Sensor *bypass_correction{nullptr};
-  binary_sensor::BinarySensor *is_bypass_valve_open{nullptr};
-  binary_sensor::BinarySensor *is_preheating{nullptr};
-  binary_sensor::BinarySensor *is_summer_mode{nullptr};
-  binary_sensor::BinarySensor *is_supply_fan_active{nullptr};
-  binary_sensor::BinarySensor *is_filter_full{nullptr};
+  binary_sensor::BinarySensor *bypass_valve_open{nullptr};
+  binary_sensor::BinarySensor *preheating{nullptr};
+  binary_sensor::BinarySensor *summer_mode{nullptr};
+  binary_sensor::BinarySensor *supply_fan_active{nullptr};
+  binary_sensor::BinarySensor *filter_full{nullptr};
 
   void set_fan_supply_air_percentage(sensor::Sensor *fan_supply_air_percentage) {this->fan_supply_air_percentage = fan_supply_air_percentage;};
   void set_fan_exhaust_air_percentage(sensor::Sensor *fan_exhaust_air_percentage) {this->fan_exhaust_air_percentage =fan_exhaust_air_percentage; };
   void set_fan_speed_supply(sensor::Sensor *fan_speed_supply) {this->fan_speed_supply =fan_speed_supply; };
   void set_fan_speed_exhaust(sensor::Sensor *fan_speed_exhaust) {this->fan_speed_exhaust =fan_speed_exhaust; };
-  void set_is_bypass_valve_open(binary_sensor::BinarySensor *is_bypass_valve_open) {this->is_bypass_valve_open =is_bypass_valve_open; };
-  void set_is_preheating(binary_sensor::BinarySensor *is_preheating) {this->is_preheating =is_preheating; };
+  void set_bypass_valve_open(binary_sensor::BinarySensor *bypass_valve_open) {this->bypass_valve_open =bypass_valve_open; };
+  void set_preheating(binary_sensor::BinarySensor *preheating) {this->preheating =preheating; };
   void set_outside_air_temperature(sensor::Sensor *outside_air_temperature) {this->outside_air_temperature =outside_air_temperature; };
   void set_supply_air_temperature(sensor::Sensor *supply_air_temperature) {this->supply_air_temperature =supply_air_temperature; };
   void set_return_air_temperature(sensor::Sensor *return_air_temperature) {this->return_air_temperature =return_air_temperature; };
@@ -581,12 +581,12 @@ public:
   void set_kitchen_hood_temperature(sensor::Sensor *kitchen_hood_temperature) {this->kitchen_hood_temperature =kitchen_hood_temperature; };
   void set_return_air_level(sensor::Sensor *return_air_level) {this->return_air_level =return_air_level; };
   void set_supply_air_level(sensor::Sensor *supply_air_level) {this->supply_air_level =supply_air_level; };
-  void set_is_supply_fan_active(binary_sensor::BinarySensor *is_supply_fan_active) {this->is_supply_fan_active =is_supply_fan_active; };
-  void set_is_filter_full(binary_sensor::BinarySensor *is_filter_full) {this->is_filter_full =is_filter_full; };
+  void set_supply_fan_active(binary_sensor::BinarySensor *supply_fan_active) {this->supply_fan_active =supply_fan_active; };
+  void set_filter_full(binary_sensor::BinarySensor *filter_full) {this->filter_full =filter_full; };
   void set_bypass_factor(sensor::Sensor *bypass_factor) {this->bypass_factor = bypass_factor; };
   void set_bypass_step(sensor::Sensor *bypass_step) {this->bypass_step = bypass_step; };
   void set_bypass_correction(sensor::Sensor *bypass_correction) {this->bypass_correction = bypass_correction; };
-  void set_is_summer_mode(binary_sensor::BinarySensor *is_summer_mode) {this->is_summer_mode = is_summer_mode; };
+  void set_summer_mode(binary_sensor::BinarySensor *summer_mode) {this->summer_mode = summer_mode; };
 };
 
 }  // namespace comfoair


### PR DESCRIPTION
This is related to issue #29 and is part 1 of 3 PR's

Removed the reliance on the `is_` prefix in the name and instead loading it from a list.
This allows for easier addition of new sensor types.

New sensors can be added in the `helper_comfoair` dictionary in `__init__.py` under their corresponding types.