### PR TITLE
Updated to ESPHome 2024.6.X

### DIFF
--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -24,6 +24,7 @@ api:
   password: 'set-an-api-password-here'
 
 ota:
+  platform: esphome
 
 sensor:
 binary_sensor:


### PR DESCRIPTION
Fixes building on ESPHome >= 2024.6.0
```
INFO ESPHome 2024.6.6
INFO Reading configuration comfoair.yaml...
INFO Cloning https://github.com/wichers/esphome-comfoair@None
Failed config

At least one platform must be specified for 'ota'; add 'platform: esphome' for original OTA functionality
```

Related to https://github.com/esphome/esphome/pull/6459

> This change only impacts the OTA configuration as it exists in YAML; it does not affect ESPHome's original OTA functionality. Existing configuration variables placed under ota: must be moved into the esphome OTA platform.