### PR TITLE
Add missing sensors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ comfoair:
     name: "ewt_present"
   options_present:
     name: "options_present"
+  fireplace_present:
+    name: "fireplace_present"
+  kitchen_hood_present:
+    name: "kitchen_hood_present"
+  postheating_present:
+    name: "postheating_present"
+  postheating_pwm_mode_present:
+    name: "postheating_pwm_mode_present"
   preheating_present:
     name: "preheating_present"
   bypass_factor:


### PR DESCRIPTION
Add missing sensors documentation to the list in README, left out from #47.