### PR TITLE
fix for: WARNING Using climate.CLIMATE_SCHEMA is deprecated and will …

### DIFF
--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -513,9 +513,9 @@ comfoair_sensors_schemas = cv.Schema(
 )
 
 CONFIG_SCHEMA = cv.All(
-    climate.CLIMATE_SCHEMA.extend(
+    climate.climate_schema(ComfoAirComponent)
+    .extend(
         {
-            cv.GenerateID(CONF_ID): cv.declare_id(ComfoAirComponent),
             cv.Required(REQUIRED_KEY_NAME): cv.string,
         }
     )


### PR DESCRIPTION
…be removed in ESPHome 2025.11.0. Please use climate.climate_schema(...) instead