### PR TITLE
fix: schema deprecations

### DIFF
--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -512,17 +512,16 @@ comfoair_sensors_schemas = cv.Schema(
     }
 )
 
-CONFIG_SCHEMA = cv.All(
-    climate.CLIMATE_SCHEMA.extend(
-        {
-            cv.GenerateID(CONF_ID): cv.declare_id(ComfoAirComponent),
-            cv.Required(REQUIRED_KEY_NAME): cv.string,
-        }
-    )
-    .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(comfoair_sensors_schemas)
+CONFIG_SCHEMA = (
+  climate.climate_schema(ComfoAirComponent)
+  .extend(
+    {
+      cv.Required(REQUIRED_KEY_NAME): cv.string,
+    }
+  )
+  .extend(uart.UART_DEVICE_SCHEMA)
+  .extend(comfoair_sensors_schemas)
 )
-
 
 def to_code(config):
     """Generates code"""


### PR DESCRIPTION
Compiling returned this warning:

WARNING Using `climate.CLIMATE_SCHEMA` is deprecated and will be removed in ESPHome 2025.11.0. Please use `climate.climate_schema(...)` instead. If you are seeing this, report an issue to the external_component author and ask them to update it. https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/. Component using this schema: comfoair

See here: https://developers.esphome.io/blog/2025/05/14/_schema-deprecations/