### PR TITLE
Fix build errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.vs
 /root@
 secrets.yaml
+.esphome

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /root@
 secrets.yaml
 .esphome
+__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.vs/slnx.sqlite
 /.vs
 /root@
+secrets.yaml

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -212,7 +212,11 @@ public:
     write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
 	}
 
-  void set_name(const char* value) {name = value;}
+  void set_name(const char* value) { name = value; }
+  void set_name(const char* value, uint32_t name_hash) {
+    (void) name_hash;
+    name = value;
+  }
   void set_uart_component(uart::UARTComponent *parent) {set_uart_parent(parent);}
   bool set_unit_size(uint8_t raw_size);
   void set_size_select(ComfoAirSizeSelect *size_select);


### PR DESCRIPTION
Added a set_name(const char*, uint32_t) overload so that the generated call compiles with a hash; the hash is ignored because the component only stores the name.

Error I was getting with the new esphome 2026.01:
```bash
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hd/bta_hd_main.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_act.c.o
In file included from src/esphome.h:30,
                 from src/main.cpp:3:
src/esphome/components/comfoair/comfoair.h: In member function 'virtual esphome::climate::ClimateTraits esphome::comfoair::ComfoAirComponent::traits()':
src/esphome/components/comfoair/comfoair.h:45:44: warning: 'void esphome::climate::ClimateTraits::set_supports_current_temperature(bool)' is deprecated: This method is deprecated, use add_feature_flags() instead [-Wdeprecated-declarations]
   45 |     traits.set_supports_current_temperature(true);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~
In file included from src/esphome/components/climate/climate.h:10,
                 from src/esphome/core/application.h:53,
                 from src/esphome/components/api/api_frame_helper.h:13,
                 from src/esphome/components/api/api_connection.h:5,
                 from src/esphome.h:3:
src/esphome/components/climate/climate_traits.h:89:8: note: declared here
   89 |   void set_supports_current_temperature(bool supports_current_temperature) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/comfoair/comfoair.h:49:53: warning: 'void esphome::climate::ClimateTraits::set_supports_two_point_target_temperature(bool)' is deprecated: This method is deprecated, use add_feature_flags() instead [-Wdeprecated-declarations]
   49 |     traits.set_supports_two_point_target_temperature(false);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
src/esphome/components/climate/climate_traits.h:111:8: note: declared here
  111 |   void set_supports_two_point_target_temperature(bool supports_two_point_target_temperature) {
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/comfoair/comfoair.h:53:31: warning: 'void esphome::climate::ClimateTraits::set_supports_action(bool)' is deprecated: This method is deprecated, use add_feature_flags() instead [-Wdeprecated-declarations]
   53 |     traits.set_supports_action(false);
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
src/esphome/components/climate/climate_traits.h:133:8: note: declared here
  133 |   void set_supports_action(bool supports_action) {
      |        ^~~~~~~~~~~~~~~~~~~
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_api.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_cfg.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_le.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_main.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hh/bta_hh_utils.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/jv/bta_jv_act.c.o
src/main.cpp: In function 'void setup()':
src/main.cpp:1124:42: error: no matching function for call to 'esphome::comfoair::ComfoAirComponent::set_name(const char [9], int)'
 1124 |   comfoair_comfoaircomponent_id->set_name("ComfoAir", 1682560679);
      |   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
src/esphome/components/comfoair/comfoair.h:215:8: note: candidate: 'void esphome::comfoair::ComfoAirComponent::set_name(const char*)'
  215 |   void set_name(const char* value) {name = value;}
      |        ^~~~~~~~
src/esphome/components/comfoair/comfoair.h:215:8: note:   candidate expects 1 argument, 2 provided
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/jv/bta_jv_api.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/jv/bta_jv_cfg.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/jv/bta_jv_main.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_act.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_api.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_at.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_cfg.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_cmd.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_main.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_rfc.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_sco.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_ag/bta_ag_sdp.c.o
Compiling .pioenvs/comfoair/bt/host/bluedroid/bta/hf_client/bta_hf_client_act.c.o
*** [.pioenvs/comfoair/src/main.cpp.o] Error 1
========================= [FAILED] Took 31.68 seconds =========================
``` 