### PR TITLE
add binary_sensor for filter_status

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ comfoair:
     name: "supply_fan_active"
   filter_status:
     name: "filter_status"
+  # Binary companion: ON when the filter is full, OFF when it is OK.
   filter_status_full:
     name: "filter_status_full"
   enthalpy_present:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ comfoair:
     name: "supply_fan_active"
   filter_status:
     name: "filter_status"
+  filter_status_full:
+    name: "filter_status_full"
   enthalpy_present:
     name: "enthalpy_present"
   ewt_present:

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -1,39 +1,70 @@
+# esphome> esphome run comfoair.yaml
 esphome:
   name: comfoair
-  platform: ESP8266
-  board: esp01_1m
-  includes:
-    - comfoair.h
 
-external_components:
-  - source:
-      type: git
-      url: https://github.com/wichers/esphome-comfoair
-    components: [comfoair]
+esp8266:
+  board: d1_mini
 
-wifi:
-  ssid: 'your-wifi-ssid-here'
-  password: 'put-your-wifi-password-here'
-
-# Disable uart logging
+# Enable logging
 logger:
-  baud_rate: 0
 
 # Enable Home Assistant API
 api:
-  password: 'set-an-api-password-here'
 
 ota:
   platform: esphome
 
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  min_auth_mode: WPA2
+
+# Enable Web server.
+web_server:
+  port: 80
+  
+# Sync time with Home Assistant.
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+
+# Button to restart.
+button:
+  - platform: restart
+    name: Restart
+  - platform: template
+    name: "Reset Filter"
+    on_press:
+      then:
+        - lambda: |-
+                id(comfoair_climate)->filter_reset();
+                    
+# Text sensors with general information.
+text_sensor:
+  # Expose ESPHome version as sensor.
+  #- platform: version
+  #  name: "ESPHome version"
+  # Expose WiFi information as sensors.
+  - platform: wifi_info
+    ip_address:
+      name: IP address
+
 sensor:
-binary_sensor:
+  - platform: wifi_signal
+    name: "WiFi Signal Sensor"
+    update_interval: 60s
+
+external_components:
+  - source:
+      type: local
+      path: components
+    components: [comfoair]
 
 uart:
   id: uart_bus
+  tx_pin: D1
+  rx_pin: D2
   baud_rate: 9600
-  tx_pin: TX
-  rx_pin: RX
 
 comfoair:
   name: "ComfoAir 350"
@@ -192,10 +223,3 @@ comfoair:
   extractor_hood_switch_off_delay_minutes:
     name: "extractor_hood_switch_off_delay_minutes"
 
-button:
-  - platform: template
-    name: "Reset Filter"
-    on_press:
-      then:
-        - lambda: |-
-                id(comfoair_climate)->filter_reset();

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -118,6 +118,8 @@ comfoair:
     name: "supply_fan_active"
   filter_status:
     name: "filter_status"
+  filter_status_full:
+    name: "filter_status_full"
   enthalpy_present:
     name: "enthalpy_present"
   ewt_present:

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -87,6 +87,8 @@ comfoair:
     name: "supply_fan_active"
   filter_status:
     name: "filter_status"
+  filter_status_full:
+    name: "filter_status_full"
   enthalpy_present:
     name: "enthalpy_present"
   ewt_present:

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -1,70 +1,39 @@
-# esphome> esphome run comfoair.yaml
 esphome:
   name: comfoair
+  platform: ESP8266
+  board: esp01_1m
+  includes:
+    - comfoair.h
 
-esp8266:
-  board: d1_mini
+external_components:
+  - source:
+      type: git
+      url: https://github.com/wichers/esphome-comfoair
+    components: [comfoair]
 
-# Enable logging
+wifi:
+  ssid: 'your-wifi-ssid-here'
+  password: 'put-your-wifi-password-here'
+
+# Disable uart logging
 logger:
+  baud_rate: 0
 
 # Enable Home Assistant API
 api:
+  password: 'set-an-api-password-here'
 
 ota:
   platform: esphome
 
-wifi:
-  ssid: !secret wifi_ssid
-  password: !secret wifi_password
-  min_auth_mode: WPA2
-
-# Enable Web server.
-web_server:
-  port: 80
-  
-# Sync time with Home Assistant.
-time:
-  - platform: homeassistant
-    id: homeassistant_time
-
-# Button to restart.
-button:
-  - platform: restart
-    name: Restart
-  - platform: template
-    name: "Reset Filter"
-    on_press:
-      then:
-        - lambda: |-
-                id(comfoair_climate)->filter_reset();
-                    
-# Text sensors with general information.
-text_sensor:
-  # Expose ESPHome version as sensor.
-  #- platform: version
-  #  name: "ESPHome version"
-  # Expose WiFi information as sensors.
-  - platform: wifi_info
-    ip_address:
-      name: IP address
-
 sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal Sensor"
-    update_interval: 60s
-
-external_components:
-  - source:
-      type: local
-      path: components
-    components: [comfoair]
+binary_sensor:
 
 uart:
   id: uart_bus
-  tx_pin: D1
-  rx_pin: D2
   baud_rate: 9600
+  tx_pin: TX
+  rx_pin: RX
 
 comfoair:
   name: "ComfoAir 350"
@@ -118,8 +87,6 @@ comfoair:
     name: "supply_fan_active"
   filter_status:
     name: "filter_status"
-  filter_status_full:
-    name: "filter_status_full"
   enthalpy_present:
     name: "enthalpy_present"
   ewt_present:
@@ -225,3 +192,10 @@ comfoair:
   extractor_hood_switch_off_delay_minutes:
     name: "extractor_hood_switch_off_delay_minutes"
 
+button:
+  - platform: template
+    name: "Reset Filter"
+    on_press:
+      then:
+        - lambda: |-
+                id(comfoair_climate)->filter_reset();

--- a/comfoair_esp32_ap.yaml
+++ b/comfoair_esp32_ap.yaml
@@ -154,6 +154,8 @@ comfoair:
     name: "Supply fan active"
   filter_status:
     name: "Filter status"
+  filter_status_full:
+    name: "filter_status_full"
   enthalpy_present:
     name: "Enthalpy present"
   ewt_present:

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -44,6 +44,7 @@ CONF_RETURN_AIR_LEVEL = "return_air_level"
 CONF_SUPPLY_AIR_LEVEL = "supply_air_level"
 CONF_SUPPLY_FAN_ACTIVE = "supply_fan_active"
 CONF_FILTER_STATUS = "filter_status"
+CONF_FILTER_STATUS_FULL = "filter_status_full"
 CONF_BYPASS_PRESENT = "bypass_present"
 CONF_ENTHALPY_PRESENT = "enthalpy_present"
 CONF_EWT_PRESENT = "ewt_present"
@@ -169,6 +170,7 @@ helper_comfoair = {
         CONF_SUMMER_MODE,
         CONF_SUPPLY_FAN_ACTIVE,
         CONF_FROST_PROTECTION_ACTIVE,
+        CONF_FILTER_STATUS_FULL,
 
         CONF_P10_ACTIVE,
         CONF_P11_ACTIVE,
@@ -479,6 +481,9 @@ comfoair_sensors_schemas = cv.Schema(
             device_class=DEVICE_CLASS_EMPTY
         ).extend(),
         cv.Optional(CONF_BYPASS_VALVE_OPEN): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_FILTER_STATUS_FULL): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_EMPTY
         ).extend(),
         cv.Optional(CONF_PREHEATING_STATE): binary_sensor.binary_sensor_schema(

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -635,6 +635,10 @@ namespace esphome
             uint8_t status = msg[8];
             filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
           }
+          if (filter_status_full != nullptr)
+          {
+            filter_status_full->publish_state(msg[8] == 1);
+          }
           break;
         }
         case RES_GET_TEMPERATURES:
@@ -1027,7 +1031,8 @@ namespace esphome
 
       void get_error_status_()
       {
-        if (filter_status != nullptr)
+        if (filter_status != nullptr ||
+            filter_status_full != nullptr)
         {
           ESP_LOGD(TAG, "getting error status");
           write_command_(CMD_GET_FAULTS, nullptr, 0);
@@ -1129,6 +1134,7 @@ namespace esphome
       text_sensor::TextSensor *type{nullptr};
       text_sensor::TextSensor *size{nullptr};
       text_sensor::TextSensor *filter_status{nullptr};
+      binary_sensor::BinarySensor *filter_status_full{nullptr};
       text_sensor::TextSensor *frost_protection_level{nullptr};
       text_sensor::TextSensor *preheating_valve{nullptr};
       sensor::Sensor *intake_fan_speed{nullptr};
@@ -1250,6 +1256,7 @@ namespace esphome
       void set_supply_air_level(sensor::Sensor *supply_air_level) { this->supply_air_level = supply_air_level; };
       void set_supply_fan_active(binary_sensor::BinarySensor *supply_fan_active) { this->supply_fan_active = supply_fan_active; };
       void set_filter_status(text_sensor::TextSensor *filter_status) { this->filter_status = filter_status; };
+      void set_filter_status_full(binary_sensor::BinarySensor *filter_status_full) { this->filter_status_full = filter_status_full; };
       void set_bypass_factor(sensor::Sensor *bypass_factor) { this->bypass_factor = bypass_factor; };
       void set_bypass_step(sensor::Sensor *bypass_step) { this->bypass_step = bypass_step; };
       void set_bypass_correction(sensor::Sensor *bypass_correction) { this->bypass_correction = bypass_correction; };

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -630,14 +630,15 @@ namespace esphome
         }
         case RES_GET_FAULTS:
         {
+          const uint8_t status = msg[8];
           if (filter_status != nullptr)
           {
-            uint8_t status = msg[8];
             filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
           }
-          if (filter_status_full != nullptr)
+          // Keep the binary sensor unknown when the protocol does not report a valid OK/full value.
+          if (filter_status_full != nullptr && status <= 1)
           {
-            filter_status_full->publish_state(msg[8] == 1);
+            filter_status_full->publish_state(status == 1);
           }
           break;
         }


### PR DESCRIPTION
Some Lovelace Cards like https://github.com/TimWeyand/lovelace-comfoair need a binary_sensor to access the filter status. However, this esphome project only supplies the text_sensor filter_status.

My change adds the binary_sensor filter_status_full which fills that gap.
