### PR TITLE
fix #72: preheating_state is unstable

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ comfoair:
     name: "bypass_valve"
   bypass_valve_open:
     name: "bypass_valve_open"
+  # Valve position: ON only when the preheating valve is open.
   preheating_state:
     name: "preheating_state"
+  # Heating activity: ON while preheating is active.
   preheating_active:
     name: "preheating_active"
   outside_air_temperature:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ comfoair:
     name: "bypass_valve_open"
   preheating_state:
     name: "preheating_state"
+  preheating_active:
+    name: "preheating_active"
   outside_air_temperature:
     name: "outside_air_temperature"
   supply_air_temperature:

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -63,6 +63,8 @@ comfoair:
     name: "bypass_valve_open"
   preheating_state:
     name: "preheating_state"
+  preheating_active:
+    name: "preheating_active"
   outside_air_temperature:
     name: "outside_air_temperature"
   supply_air_temperature:

--- a/comfoair_esp32_ap.yaml
+++ b/comfoair_esp32_ap.yaml
@@ -130,6 +130,8 @@ comfoair:
     name: "Bypass open"
   preheating_state:
     name: "Preheating state"
+  preheating_active:
+    name: "preheating_active"
   outside_air_temperature:
     name: "Outside temperature"
   supply_air_temperature:

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -32,6 +32,7 @@ CONF_INTAKE_FAN_SPEED_RPM = "intake_fan_speed_rpm"
 CONF_EXHAUST_FAN_SPEED_RPM = "exhaust_fan_speed_rpm"
 CONF_VENTILATION_LEVEL = "ventilation_level"
 CONF_PREHEATING_STATE = "preheating_state"
+CONF_PREHEATING_ACTIVE = "preheating_active"
 CONF_OUTSIDE_AIR_TEMPERATURE = "outside_air_temperature"
 CONF_SUPPLY_AIR_TEMPERATURE = "supply_air_temperature"
 CONF_RETURN_AIR_TEMPERATURE = "return_air_temperature"
@@ -166,6 +167,7 @@ helper_comfoair = {
         CONF_PREHEATING_PRESENT,
         CONF_BYPASS_VALVE_OPEN,
         CONF_PREHEATING_STATE,
+        CONF_PREHEATING_ACTIVE,
         CONF_SUMMER_MODE,
         CONF_SUPPLY_FAN_ACTIVE,
         CONF_FROST_PROTECTION_ACTIVE,
@@ -482,6 +484,9 @@ comfoair_sensors_schemas = cv.Schema(
             device_class=DEVICE_CLASS_EMPTY
         ).extend(),
         cv.Optional(CONF_PREHEATING_STATE): binary_sensor.binary_sensor_schema(
+            device_class=DEVICE_CLASS_EMPTY
+        ).extend(),
+        cv.Optional(CONF_PREHEATING_ACTIVE): binary_sensor.binary_sensor_schema(
             device_class=DEVICE_CLASS_EMPTY
         ).extend(),
         cv.Optional(CONF_SUMMER_MODE): binary_sensor.binary_sensor_schema(

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -496,7 +496,7 @@ namespace esphome
           }
           if (preheating_state != nullptr)
           {
-            preheating_state->publish_state(msg[1] != 0);
+            preheating_state->publish_state(msg[1] == 1);
           }
           if (motor_current_bypass != nullptr)
           {
@@ -916,9 +916,9 @@ namespace esphome
             frost_protection_active->publish_state(msg[1] != 0);
           }
 
-          if (preheating_state != nullptr)
+          if (preheating_active != nullptr)
           {
-            preheating_state->publish_state(msg[2] != 0);
+            preheating_active->publish_state(msg[2] != 0);
           }
 
           if (frost_protection_minutes != nullptr)
@@ -1173,6 +1173,7 @@ namespace esphome
       binary_sensor::BinarySensor *postheating_pwm_mode_present{nullptr};
       binary_sensor::BinarySensor *bypass_valve_open{nullptr};
       binary_sensor::BinarySensor *preheating_state{nullptr};
+      binary_sensor::BinarySensor *preheating_active{nullptr};
       binary_sensor::BinarySensor *summer_mode{nullptr};
       binary_sensor::BinarySensor *supply_fan_active{nullptr};
       binary_sensor::BinarySensor *p10_active{nullptr};
@@ -1238,6 +1239,7 @@ namespace esphome
       void set_postheating_pwm_mode_present(binary_sensor::BinarySensor *postheating_pwm_mode_present) { this->postheating_pwm_mode_present = postheating_pwm_mode_present; };
       void set_bypass_valve_open(binary_sensor::BinarySensor *bypass_valve_open) { this->bypass_valve_open = bypass_valve_open; };
       void set_preheating_state(binary_sensor::BinarySensor *preheating_state) { this->preheating_state = preheating_state; };
+      void set_preheating_active(binary_sensor::BinarySensor *preheating_active) { this->preheating_active = preheating_active; };
       void set_outside_air_temperature(sensor::Sensor *outside_air_temperature) { this->outside_air_temperature = outside_air_temperature; };
       void set_supply_air_temperature(sensor::Sensor *supply_air_temperature) { this->supply_air_temperature = supply_air_temperature; };
       void set_return_air_temperature(sensor::Sensor *return_air_temperature) { this->return_air_temperature = return_air_temperature; };

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -494,7 +494,8 @@ namespace esphome
           {
             bypass_valve_open->publish_state(msg[0] != 0);
           }
-          if (preheating_state != nullptr)
+          // Value 2 means unknown; do not publish it as a false closed state.
+          if (preheating_state != nullptr && msg[1] <= 1)
           {
             preheating_state->publish_state(msg[1] == 1);
           }
@@ -916,9 +917,9 @@ namespace esphome
             frost_protection_active->publish_state(msg[1] != 0);
           }
 
-          if (preheating_active != nullptr)
+          if (preheating_active != nullptr && msg[2] <= 1)
           {
-            preheating_active->publish_state(msg[2] != 0);
+            preheating_active->publish_state(msg[2] == 1);
           }
 
           if (frost_protection_minutes != nullptr)


### PR DESCRIPTION
The binary_sensor preheating_state was set from two different messages:
- RES_GET_VALVE_STATUS: msg[1]
- RES_GET_PREHEATING_STATUS: msg[2]

I added a new binary_sensor preheating_active that is now used for RES_GET_PREHEATING_STATUS instead of preheating_state.