### PR TITLE
Integrate parsley fork protocol updates

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,11 +1,18 @@
 name: Pylint
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
@@ -16,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        pip install pylint esphome
+        python -m pip install pylint esphome
     - name: Analysing the code with pylint
       run: |
-        pylint $(git ls-files '*.py')
+        git ls-files -z '*.py' | xargs -0 python -m pylint

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 secrets.yaml
 .esphome
 __pycache__
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # ComfoAir
 Port of the ComfoAir protocol to ESPHome.io firmware, which is supported by external_components.
 
+The component sends one protocol request every two seconds. After the initial
+version/status requests, the regular ten-request sensor cycle completes roughly
+every 20 seconds.
+
+Ready-to-adapt MQTT/web-server examples are included for `esp32-s3-devkitc-1`
+and `wemos_d1_mini32` boards. They intentionally leave the Home Assistant
+native API disabled.
+
 Add the following definition of `external_components` to your yaml configuration:
 
 ```

--- a/comfoair.yaml
+++ b/comfoair.yaml
@@ -1,9 +1,9 @@
+esp8266:
+  board: esp01_1m
 esphome:
   name: comfoair
-  platform: ESP8266
-  board: esp01_1m
-  includes:
-    - comfoair.h
+  # includes:
+  #   - comfoair.h
 
 external_components:
   - source:
@@ -21,7 +21,6 @@ logger:
 
 # Enable Home Assistant API
 api:
-  password: 'set-an-api-password-here'
 
 ota:
   platform: esphome

--- a/comfoair_esp32-s3-devkitc-1.yaml
+++ b/comfoair_esp32-s3-devkitc-1.yaml
@@ -1,0 +1,614 @@
+# ### Substitutions ###
+# <https://esphome.io/components/substitutions>
+substitutions:
+  node_name: comfoair # [a-z][0-9][_] max 24 characters, unique name per network!
+  device_name: "Zehnder ComfoAir 350"
+  node_comment: "ESPhome controller for ComfoAir 350" # Additional text information about this node. Only for display in UI.
+  ota_password: !secret comfoair_ota_password
+
+# ### Core configuration ###
+# <https://esphome.io/components/esphome>
+esphome:
+  name: ${node_name}
+  friendly_name: "${device_name}"
+  comment: ${node_comment}
+  area: lab #livingroom
+  project:
+    name: "parsley.comfoair" # author_name.project_name
+    version: "1.1.0"
+  # debug_scheduler: false
+  on_boot:
+    # default to red LED when connecting
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 100%
+        green: 0%
+        blue: 0%
+  # on_loop:
+
+# ### Supported Microcontrollers ###
+# <https://esphome.io/components/esp32>
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 4MB
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: quad
+  speed: 80MHz
+
+light:
+  - platform: esp32_rmt_led_strip
+    id: status_light
+    chipset: WS2812
+    pin: GPIO21 # GPIO48
+    num_leds: 1
+    rgb_order: GRB
+    name: "WS2812B Light"
+    restore_mode: ALWAYS_ON
+
+# ----- software & libraries -----
+
+# ----- external_components -----
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/parsley/esphome-comfoair
+    components: [comfoair]
+
+# ----- Communication connections (wifi, webserver, HomeAssistent-api, mqtt) -----
+
+# ### Network Hardware ###
+# <https://esphome.io/components/wifi>
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: ${node_name}-setup
+    password: !secret wifi_fallback_ap_key
+  # reboot_timeout: 0s
+  # power_save_mode: none # NONE (least power saving, Default for ESP8266), LIGHT (Default for ESP32), HIGH (most power saving)
+  on_connect:
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 0%
+        green: 100%
+        blue: 0%
+  on_disconnect:
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 0%
+        green: 50%
+        blue: 50%
+
+# ### Captive Portal ###
+# Enable captive portal on fallback hotspot (in case wifi connection fails)
+# <https://esphome.io/components/captive_portal>
+captive_portal:
+
+# ### Management and Monitoring ###
+# <https://esphome.io/components/web_server>
+web_server:
+  port: 80
+  ota: false
+  local: true
+  version: 3
+  # auth:
+  #   username: !secret web_server_username
+  #   password: !secret web_server_password
+  sorting_groups:
+    - id: sorting_group_10_temperatures
+      name: "Comfo Actual Temperatures"
+      sorting_weight: 10 # lower value gets sorted above higher. default value is 50
+    - id: sorting_group_20_bypass
+      name: "Comfo Bypass"
+      sorting_weight: 20
+    - id: sorting_group_30_fan
+      name: "Comfo Fans"
+      sorting_weight: 30
+    - id: sorting_group_30_filter
+      name: "Comfo Filter"
+      sorting_weight: 31
+    - id: sorting_group_30_statistics
+      name: "Comfo Statistics"
+      sorting_weight: 32
+    - id: sorting_group_35_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 35
+    - id: sorting_group_40_configuration
+      name: "Comfo Configuration"
+      sorting_weight: 40
+    - id: sorting_group_50_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 50
+    - id: sorting_group_60_setup
+      name: "Comfo Parameter Setup"
+      sorting_weight: 60
+    - id: sorting_group_70_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 70
+
+# ### Native API Component ### (Home Assistant API)
+# <https://esphome.io/components/api>
+# api:
+#   encryption:
+#     key: !secret comfoair_api_encryption_key
+#   reboot_timeout: 0s # disable reboot (0s), default: 15min
+#   custom_services: true
+
+# ### MQTT Client Component ###
+# <https://esphome.io/components/mqtt>
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  port: 1883
+  # clean_session: false # default
+  # discover_ip: false
+  # discovery: false
+  # discovery_retain: false
+  # reboot_timeout: 0s
+  # topic_prefix:
+  # log_topic:
+
+# Programming and debugging
+
+# ### Logger Component ###
+# <https://esphome.io/components/logger>
+logger:
+  # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
+  level: DEBUG # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+
+# ### Over-the-Air Updates ###
+# <https://esphome.io/components/ota/>
+ota:
+  - platform: esphome # <https://esphome.io/components/ota/esphome>
+    password: ${ota_password}
+    on_begin:
+      then:
+        # Turn the LED Red when OTA Updating
+        - light.turn_on:
+            id: status_light
+            brightness: 40%
+            red: 40%
+            green: 0%
+            blue: 0%
+            transition_length: 0s
+        - lambda: "id(status_light).loop();"
+
+# Select
+# Logger Select - Example configuration entry
+# <https://esphome.io/components/select/logger>
+# select select_level:
+# <https://github.com/esphome/feature-requests/issues/3151>
+select:
+  - platform: logger
+    name: "Logger select"
+  - platform: template
+    name: Select Level
+    id: select_level
+    options:
+      - "Auto"
+      - "Absent"
+      - "low"
+      - "medium"
+      - "high"
+    initial_option: "medium"
+    optimistic: True
+    on_value:
+      then:
+        - lambda: |-
+            switch(i){
+            case 0:
+              id(comfoair_climate).set_level(0);
+              break;
+            case 1:
+              id(comfoair_climate).set_level(1);
+              break;
+            case 2:
+              id(comfoair_climate).set_level(2);
+              break;
+            case 3:
+              id(comfoair_climate).set_level(3);
+              break;
+            case 4:
+              id(comfoair_climate).set_level(4);
+              break;
+            default:
+              id(comfoair_climate).set_level(1);
+            }
+
+# sensors / inputs / outputs
+
+# http_request:
+
+# output:
+#   - platform: gpio
+#     id: orange_led_out
+#     pin: GPIO18
+#   - platform: gpio
+#     id: green_led_out
+#     pin: GPIO19
+
+# interval:
+#   - interval: 1s
+#     then:
+#       if:
+#         condition:
+#           wifi.connected:
+#         then:
+#           - output.turn_off: green_led_out
+#         else:
+#           - output.turn_on: green_led_out
+#           - delay: 500ms
+#           - output.turn_off: green_led_out
+#   - interval: 500ms
+#     then:
+#       if:
+#         condition:
+#           api.connected:
+#         then:
+#           - output.turn_off: orange_led_out
+#         else:
+#           - if:
+#               condition:
+#                 wifi.connected
+#               then:
+#                 - output.turn_on: orange_led_out
+#                 - delay: 250ms
+#                 - output.turn_off: orange_led_out
+#               else:
+#                 - output.turn_off: orange_led_out
+
+sensor:
+  - platform: uptime
+    name: "Uptime"
+  - platform: wifi_signal
+    name: "WiFi Signal Strength"
+    update_interval: 60s
+
+# binary_sensor:
+
+switch:
+  - platform: factory_reset
+    name: Restart with Factory Default Settings
+
+button:
+  - platform: restart
+    id: reset_button
+    name: "Reset ESP32 Comfoair Adapter"
+  - platform: template
+    id: filter_reset_button
+    name: "Reset Filter"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+    on_press:
+      then:
+        lambda: "id(comfoair_climate).reset_filters();"
+
+text_sensor:
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+uart:
+  id: uart_bus
+  baud_rate: 9600
+  tx_pin: GPIO43
+  rx_pin: GPIO44
+
+comfoair:
+  id: comfoair_climate
+  name: "${node_name}"
+  uart_id: uart_bus
+  type:
+    name: "Type" # left
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  size:
+    name: "Size" # small
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  size_select:
+    name: "unit_size"
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  intake_fan_speed:
+    name: "Fan Supply air level" # %
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  exhaust_fan_speed:
+    name: "Fan Return air level" # %
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  intake_fan_speed_rpm:
+    name: "Fan Intake fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  exhaust_fan_speed_rpm:
+    name: "Fan Exhaust fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  ventilation_level:
+    name: "Ventilation level" # 0...3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  bypass_present:
+    name: "Bypass present" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  bypass_valve:
+    name: "Bypass valve" # %
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_valve_open:
+    name: "Bypass open"  # yes/no
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  preheating_state:
+    name: "Preheating state" # ON
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  outside_air_temperature:
+    name: "T1 Outside temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  supply_air_temperature:
+    name: "T2 Supply temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  return_air_temperature:
+    name: "T3 Return temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  exhaust_air_temperature:
+    name: "T4 Exhaust temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  enthalpy_temperature:
+    name: "Enthalpy temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  ewt_temperature:
+    name: "EWT temperature "
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  reheating_temperature:
+    name: "Reheating temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  kitchen_hood_temperature:
+    name: "Kitchen hood temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  return_air_level:
+    name: "Fan Return level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  supply_air_level:
+    name: "Fan Supply level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  supply_fan_active:
+    name: "Fan Supply fan active" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  filter_status:
+    name: "Filter status" # Filter ok/Filter voll
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  enthalpy_present:
+    name: "Enthalpy present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  ewt_present:
+    name: "EWT present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  options_present:
+    name: "Options present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  fireplace_present:
+    name: "fireplace_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  kitchen_hood_present:
+    name: "kitchen_hood_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  postheating_present:
+    name: "postheating_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  postheating_pwm_mode_present:
+    name: "postheating_pwm_mode_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  preheating_present:
+    name: "Preheating present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  bypass_factor:
+    name: "Bypass factor" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_step:
+    name: "Bypass step" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_correction:
+    name: "Bypass correction" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_open_hours:
+    name: "Bypass open hours" # h
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  preheating_hours:
+    name: "Preheating hours" # 0
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level0_hours:
+    name: "Level 0 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level1_hours:
+    name: "Level 1 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level2_hours:
+    name: "Level 2 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level3_hours:
+    name: "Level 3 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  preheating_valve:
+    name: "Preheating valve" # Unknown
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_active:
+    name: "Frost protection active"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_hours:
+    name: "Frost protection hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  frost_protection_minutes:
+    name: "Frost protection minutes"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_level:
+    name: "Frost protection level"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  filter_hours:
+    name: "Filter hours" # "Betriebsstunden Filter"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  motor_current_bypass:
+    name: "Bypass motor current" # A
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  motor_current_preheating:
+    name: "Motor current preheating" # 0.0
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  summer_mode:
+    name: "Summer mode"
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  p10_active:
+    name: "P10 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p11_active:
+    name: "P11 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p12_active:
+    name: "P12 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p13_active:
+    name: "P13 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p14_active:
+    name: "P14 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p15_active:
+    name: "P15 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p16_active:
+    name: "P16 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p17_active:
+    name: "P17 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p18_active:
+    name: "P18 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p19_active:
+    name: "P19 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p90_active:
+    name: "P90 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p91_active:
+    name: "P91 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p92_active:
+    name: "P92 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p93_active:
+    name: "P93 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p94_active:
+    name: "P94 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p95_active:
+    name: "P95 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p96_active:
+    name: "P96 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p97_active:
+    name: "P97 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  bathroom_switch_on_delay_minutes:
+    name: "Bathroom switch on delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  bathroom_switch_off_delay_minutes:
+    name: "Bathroom switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  l1_switch_off_delay_minutes:
+    name: "L1 switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  boost_ventilation_minutes:
+    name: "Boost ventilation minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  filter_warning_weeks:
+    name: "Filter warning weeks" # "Filter Zähler Wochen"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  rf_high_time_short_minutes:
+    name: "RF high time short minutes" # 10
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  rf_high_time_long_minutes:
+    name: "RF high time long minutes" # 30
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  extractor_hood_switch_off_delay_minutes:
+    name: "Extractor hood switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration

--- a/comfoair_esp32-s3-devkitc-1.yaml
+++ b/comfoair_esp32-s3-devkitc-1.yaml
@@ -104,36 +104,36 @@ web_server:
   #   username: !secret web_server_username
   #   password: !secret web_server_password
   sorting_groups:
-    - id: sorting_group_10_temperatures
+    - id: sorting_group_temperatures
       name: "Comfo Actual Temperatures"
       sorting_weight: 10 # lower value gets sorted above higher. default value is 50
-    - id: sorting_group_20_bypass
+    - id: sorting_group_bypass
       name: "Comfo Bypass"
       sorting_weight: 20
-    - id: sorting_group_30_fan
+    - id: sorting_group_fan
       name: "Comfo Fans"
       sorting_weight: 30
-    - id: sorting_group_30_filter
+    - id: sorting_group_filter
       name: "Comfo Filter"
-      sorting_weight: 31
-    - id: sorting_group_30_statistics
-      name: "Comfo Statistics"
-      sorting_weight: 32
-    - id: sorting_group_35_Frost_Heat
-      name: "Comfo Heating and Frost Protection"
-      sorting_weight: 35
-    - id: sorting_group_40_configuration
-      name: "Comfo Configuration"
       sorting_weight: 40
-    - id: sorting_group_50_settings
-      name: "Comfo Parameter Settings"
+    - id: sorting_group_configuration
+      name: "Comfo Configuration"
       sorting_weight: 50
-    - id: sorting_group_60_setup
+    - id: sorting_group_setup
       name: "Comfo Parameter Setup"
       sorting_weight: 60
-    - id: sorting_group_70_features_present
-      name: "Comfo Features Present"
+    - id: sorting_group_statistics
+      name: "Comfo Statistics"
       sorting_weight: 70
+    - id: sorting_group_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 80
+    - id: sorting_group_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 90
+    - id: sorting_group_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 100
 
 # ### Native API Component ### (Home Assistant API)
 # <https://esphome.io/components/api>
@@ -164,7 +164,8 @@ mqtt:
 # <https://esphome.io/components/logger>
 logger:
   # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
-  level: DEBUG # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  level: VERY_VERBOSE # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  initial_level: INFO
 
 # ### Over-the-Air Updates ###
 # <https://esphome.io/components/ota/>
@@ -195,8 +196,8 @@ select:
     name: Select Level
     id: select_level
     options:
-      - "Auto"
-      - "Absent"
+      - "auto"
+      - "absent"
       - "low"
       - "medium"
       - "high"
@@ -288,7 +289,7 @@ button:
     id: filter_reset_button
     name: "Reset Filter"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
     on_press:
       then:
         lambda: "id(comfoair_climate).reset_filters();"
@@ -311,304 +312,304 @@ comfoair:
   type:
     name: "Type" # left
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   size:
     name: "Size" # small
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   size_select:
-    name: "unit_size"
+    name: "Size (unit_size)"
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   intake_fan_speed:
     name: "Fan Supply air level" # %
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   exhaust_fan_speed:
     name: "Fan Return air level" # %
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   intake_fan_speed_rpm:
     name: "Fan Intake fan RPM" # RPM
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   exhaust_fan_speed_rpm:
     name: "Fan Exhaust fan RPM" # RPM
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   ventilation_level:
     name: "Ventilation level" # 0...3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   bypass_present:
     name: "Bypass present" # yes/no
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   bypass_valve:
     name: "Bypass valve" # %
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_valve_open:
     name: "Bypass open"  # yes/no
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   preheating_state:
     name: "Preheating state" # ON
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   outside_air_temperature:
     name: "T1 Outside temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   supply_air_temperature:
     name: "T2 Supply temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   return_air_temperature:
     name: "T3 Return temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   exhaust_air_temperature:
     name: "T4 Exhaust temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   enthalpy_temperature:
     name: "Enthalpy temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   ewt_temperature:
     name: "EWT temperature "
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   reheating_temperature:
     name: "Reheating temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   kitchen_hood_temperature:
     name: "Kitchen hood temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   return_air_level:
     name: "Fan Return level" # m^3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   supply_air_level:
     name: "Fan Supply level" # m^3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   supply_fan_active:
     name: "Fan Supply fan active" # yes/no
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   filter_status:
     name: "Filter status" # Filter ok/Filter voll
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   enthalpy_present:
     name: "Enthalpy present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   ewt_present:
     name: "EWT present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   options_present:
     name: "Options present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   fireplace_present:
     name: "fireplace_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   kitchen_hood_present:
     name: "kitchen_hood_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   postheating_present:
     name: "postheating_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   postheating_pwm_mode_present:
     name: "postheating_pwm_mode_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   preheating_present:
     name: "Preheating present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   bypass_factor:
     name: "Bypass factor" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_step:
     name: "Bypass step" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_correction:
     name: "Bypass correction" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_open_hours:
     name: "Bypass open hours" # h
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   preheating_hours:
     name: "Preheating hours" # 0
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level0_hours:
     name: "Level 0 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level1_hours:
     name: "Level 1 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level2_hours:
     name: "Level 2 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level3_hours:
     name: "Level 3 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   preheating_valve:
     name: "Preheating valve" # Unknown
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_active:
     name: "Frost protection active"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_hours:
     name: "Frost protection hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   frost_protection_minutes:
     name: "Frost protection minutes"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_level:
     name: "Frost protection level"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   filter_hours:
     name: "Filter hours" # "Betriebsstunden Filter"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   motor_current_bypass:
     name: "Bypass motor current" # A
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   motor_current_preheating:
     name: "Motor current preheating" # 0.0
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   summer_mode:
     name: "Summer mode"
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   p10_active:
     name: "P10 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p11_active:
     name: "P11 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p12_active:
     name: "P12 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p13_active:
     name: "P13 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p14_active:
     name: "P14 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p15_active:
     name: "P15 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p16_active:
     name: "P16 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p17_active:
     name: "P17 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p18_active:
     name: "P18 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p19_active:
     name: "P19 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p90_active:
     name: "P90 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p91_active:
     name: "P91 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p92_active:
     name: "P92 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p93_active:
     name: "P93 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p94_active:
     name: "P94 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p95_active:
     name: "P95 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p96_active:
     name: "P96 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p97_active:
     name: "P97 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   bathroom_switch_on_delay_minutes:
     name: "Bathroom switch on delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   bathroom_switch_off_delay_minutes:
     name: "Bathroom switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   l1_switch_off_delay_minutes:
     name: "L1 switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   boost_ventilation_minutes:
     name: "Boost ventilation minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   filter_warning_weeks:
     name: "Filter warning weeks" # "Filter Zähler Wochen"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   rf_high_time_short_minutes:
     name: "RF high time short minutes" # 10
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   rf_high_time_long_minutes:
     name: "RF high time long minutes" # 30
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   extractor_hood_switch_off_delay_minutes:
     name: "Extractor hood switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration

--- a/comfoair_esp32-s3-devkitc-1.yaml
+++ b/comfoair_esp32-s3-devkitc-1.yaml
@@ -1,0 +1,623 @@
+# ### Substitutions ###
+# <https://esphome.io/components/substitutions>
+substitutions:
+  node_name: comfoair # [a-z][0-9][_] max 24 characters, unique name per network!
+  device_name: "Zehnder ComfoAir 350"
+  node_comment: "ESPhome controller for ComfoAir 350" # Additional text information about this node. Only for display in UI.
+  ota_password: !secret comfoair_ota_password
+
+# ### Core configuration ###
+# <https://esphome.io/components/esphome>
+esphome:
+  name: ${node_name}
+  friendly_name: "${device_name}"
+  comment: ${node_comment}
+  area: lab #livingroom
+  project:
+    name: "wichers.comfoair" # author_name.project_name
+    version: "1.1.0"
+  # debug_scheduler: false
+  on_boot:
+    # default to red LED when connecting
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 100%
+        green: 0%
+        blue: 0%
+  # on_loop:
+
+# ### Supported Microcontrollers ###
+# <https://esphome.io/components/esp32>
+esp32:
+  board: esp32-s3-devkitc-1
+  flash_size: 4MB
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: quad
+  speed: 80MHz
+
+light:
+  - platform: esp32_rmt_led_strip
+    id: status_light
+    chipset: WS2812
+    pin: GPIO21 # GPIO48
+    num_leds: 1
+    rgb_order: GRB
+    name: "WS2812B Light"
+    restore_mode: ALWAYS_ON
+
+# ----- software & libraries -----
+
+# ----- external_components -----
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/wichers/esphome-comfoair
+    components: [comfoair]
+
+# ----- Communication connections (wifi, webserver, HomeAssistent-api, mqtt) -----
+
+# ### Network Hardware ###
+# <https://esphome.io/components/wifi>
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: ${node_name}-setup
+    password: !secret wifi_fallback_ap_key
+  # reboot_timeout: 0s
+  # power_save_mode: none # NONE (least power saving, Default for ESP8266), LIGHT (Default for ESP32), HIGH (most power saving)
+  on_connect:
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 0%
+        green: 100%
+        blue: 0%
+  on_disconnect:
+    - light.turn_on:
+        id: status_light
+        brightness: 20%
+        red: 0%
+        green: 50%
+        blue: 50%
+
+# ### Captive Portal ###
+# Enable captive portal on fallback hotspot (in case wifi connection fails)
+# <https://esphome.io/components/captive_portal>
+captive_portal:
+
+# ### Management and Monitoring ###
+# <https://esphome.io/components/web_server>
+web_server:
+  port: 80
+  ota: false
+  local: true
+  version: 3
+  # auth:
+  #   username: !secret web_server_username
+  #   password: !secret web_server_password
+  sorting_groups:
+    - id: sorting_group_temperatures
+      name: "Comfo Actual Temperatures"
+      sorting_weight: 10 # lower value gets sorted above higher. default value is 50
+    - id: sorting_group_bypass
+      name: "Comfo Bypass"
+      sorting_weight: 20
+    - id: sorting_group_fan
+      name: "Comfo Fans"
+      sorting_weight: 30
+    - id: sorting_group_filter
+      name: "Comfo Filter"
+      sorting_weight: 40
+    - id: sorting_group_configuration
+      name: "Comfo Configuration"
+      sorting_weight: 50
+    - id: sorting_group_setup
+      name: "Comfo Parameter Setup"
+      sorting_weight: 60
+    - id: sorting_group_statistics
+      name: "Comfo Statistics"
+      sorting_weight: 70
+    - id: sorting_group_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 80
+    - id: sorting_group_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 90
+    - id: sorting_group_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 100
+
+# ### Native API Component ### (Home Assistant API)
+# <https://esphome.io/components/api>
+# api:
+#   encryption:
+#     key: !secret comfoair_api_encryption_key
+#   reboot_timeout: 0s # disable reboot (0s), default: 15min
+#   custom_services: true
+
+# ### MQTT Client Component ###
+# <https://esphome.io/components/mqtt>
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  port: 1883
+  # clean_session: false # default
+  # discover_ip: false
+  # discovery: false
+  # discovery_retain: false
+  # reboot_timeout: 0s
+  # topic_prefix:
+  # log_topic:
+
+# Programming and debugging
+
+# ### Logger Component ###
+# <https://esphome.io/components/logger>
+logger:
+  # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
+  level: VERY_VERBOSE # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  initial_level: INFO
+
+# ### Over-the-Air Updates ###
+# <https://esphome.io/components/ota/>
+ota:
+  - platform: esphome # <https://esphome.io/components/ota/esphome>
+    password: ${ota_password}
+    on_begin:
+      then:
+        # Turn the LED Red when OTA Updating
+        - light.turn_on:
+            id: status_light
+            brightness: 40%
+            red: 40%
+            green: 0%
+            blue: 0%
+            transition_length: 0s
+        - lambda: "id(status_light).loop();"
+
+# Select
+# Logger Select - Example configuration entry
+# <https://esphome.io/components/select/logger>
+# select select_level:
+# <https://github.com/esphome/feature-requests/issues/3151>
+select:
+  - platform: logger
+    name: "Logger select"
+  - platform: template
+    name: Select Level
+    id: select_level
+    options:
+      - "auto"
+      - "absent"
+      - "low"
+      - "medium"
+      - "high"
+    initial_option: "medium"
+    optimistic: True
+    on_value:
+      then:
+        - lambda: |-
+            switch(i){
+            case 0:
+              id(comfoair_climate).set_level(0);
+              break;
+            case 1:
+              id(comfoair_climate).set_level(1);
+              break;
+            case 2:
+              id(comfoair_climate).set_level(2);
+              break;
+            case 3:
+              id(comfoair_climate).set_level(3);
+              break;
+            case 4:
+              id(comfoair_climate).set_level(4);
+              break;
+            default:
+              id(comfoair_climate).set_level(1);
+            }
+
+# sensors / inputs / outputs
+
+# http_request:
+
+# output:
+#   - platform: gpio
+#     id: orange_led_out
+#     pin: GPIO18
+#   - platform: gpio
+#     id: green_led_out
+#     pin: GPIO19
+
+# interval:
+#   - interval: 1s
+#     then:
+#       if:
+#         condition:
+#           wifi.connected:
+#         then:
+#           - output.turn_off: green_led_out
+#         else:
+#           - output.turn_on: green_led_out
+#           - delay: 500ms
+#           - output.turn_off: green_led_out
+#   - interval: 500ms
+#     then:
+#       if:
+#         condition:
+#           api.connected:
+#         then:
+#           - output.turn_off: orange_led_out
+#         else:
+#           - if:
+#               condition:
+#                 wifi.connected
+#               then:
+#                 - output.turn_on: orange_led_out
+#                 - delay: 250ms
+#                 - output.turn_off: orange_led_out
+#               else:
+#                 - output.turn_off: orange_led_out
+
+sensor:
+  - platform: uptime
+    name: "Uptime"
+  - platform: wifi_signal
+    name: "WiFi Signal Strength"
+    update_interval: 60s
+
+# binary_sensor:
+
+switch:
+  - platform: factory_reset
+    name: Restart with Factory Default Settings
+
+button:
+  - platform: restart
+    id: reset_button
+    name: "Reset ESP32 Comfoair Adapter"
+  - platform: template
+    id: filter_reset_button
+    name: "Reset Filter"
+    web_server:
+      sorting_group_id: sorting_group_filter
+    on_press:
+      then:
+        lambda: "id(comfoair_climate).reset_filters();"
+
+text_sensor:
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+uart:
+  id: uart_bus
+  baud_rate: 9600
+  tx_pin: GPIO43
+  rx_pin: GPIO44
+
+comfoair:
+  id: comfoair_climate
+  name: "${node_name}"
+  uart_id: uart_bus
+  type:
+    name: "Type" # left
+    web_server:
+      sorting_group_id: sorting_group_setup
+  size:
+    name: "Size" # small
+    web_server:
+      sorting_group_id: sorting_group_setup
+  size_select:
+    name: "Size (unit_size)"
+    web_server:
+      sorting_group_id: sorting_group_setup
+  intake_fan_speed:
+    name: "Fan Supply air level" # %
+    web_server:
+      sorting_group_id: sorting_group_fan
+  exhaust_fan_speed:
+    name: "Fan Return air level" # %
+    web_server:
+      sorting_group_id: sorting_group_fan
+  intake_fan_speed_rpm:
+    name: "Fan Intake fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_fan
+  exhaust_fan_speed_rpm:
+    name: "Fan Exhaust fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_fan
+  ventilation_level:
+    name: "Ventilation level" # 0...3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  bypass_present:
+    name: "Bypass present" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  bypass_valve:
+    name: "Bypass valve" # %
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_valve_open:
+    name: "Bypass open"  # yes/no
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  preheating_state:
+    name: "Preheating state" # ON
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  preheating_active:
+    name: "Preheating active"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  outside_air_temperature:
+    name: "T1 Outside temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  supply_air_temperature:
+    name: "T2 Supply temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  return_air_temperature:
+    name: "T3 Return temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  exhaust_air_temperature:
+    name: "T4 Exhaust temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  enthalpy_temperature:
+    name: "Enthalpy temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  ewt_temperature:
+    name: "EWT temperature "
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  reheating_temperature:
+    name: "Reheating temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  kitchen_hood_temperature:
+    name: "Kitchen hood temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  return_air_level:
+    name: "Fan Return level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  supply_air_level:
+    name: "Fan Supply level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  supply_fan_active:
+    name: "Fan Supply fan active" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_fan
+  filter_status:
+    name: "Filter status" # Filter ok/Filter voll
+    web_server:
+      sorting_group_id: sorting_group_filter
+  filter_status_full:
+    name: "Filter full"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  enthalpy_present:
+    name: "Enthalpy present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  ewt_present:
+    name: "EWT present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  options_present:
+    name: "Options present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  fireplace_present:
+    name: "fireplace_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  kitchen_hood_present:
+    name: "kitchen_hood_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  postheating_present:
+    name: "postheating_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  postheating_pwm_mode_present:
+    name: "postheating_pwm_mode_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  preheating_present:
+    name: "Preheating present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  bypass_factor:
+    name: "Bypass factor" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_step:
+    name: "Bypass step" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_correction:
+    name: "Bypass correction" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_open_hours:
+    name: "Bypass open hours" # h
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  preheating_hours:
+    name: "Preheating hours" # 0
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level0_hours:
+    name: "Level 0 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level1_hours:
+    name: "Level 1 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level2_hours:
+    name: "Level 2 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level3_hours:
+    name: "Level 3 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  preheating_valve:
+    name: "Preheating valve" # Unknown
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_active:
+    name: "Frost protection active"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_hours:
+    name: "Frost protection hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  frost_protection_minutes:
+    name: "Frost protection minutes"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_level:
+    name: "Frost protection level"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  filter_hours:
+    name: "Filter hours" # "Betriebsstunden Filter"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  motor_current_bypass:
+    name: "Bypass motor current" # A
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  motor_current_preheating:
+    name: "Motor current preheating" # 0.0
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  summer_mode:
+    name: "Summer mode"
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  p10_active:
+    name: "P10 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p11_active:
+    name: "P11 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p12_active:
+    name: "P12 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p13_active:
+    name: "P13 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p14_active:
+    name: "P14 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p15_active:
+    name: "P15 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p16_active:
+    name: "P16 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p17_active:
+    name: "P17 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p18_active:
+    name: "P18 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p19_active:
+    name: "P19 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p90_active:
+    name: "P90 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p91_active:
+    name: "P91 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p92_active:
+    name: "P92 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p93_active:
+    name: "P93 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p94_active:
+    name: "P94 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p95_active:
+    name: "P95 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p96_active:
+    name: "P96 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p97_active:
+    name: "P97 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  bathroom_switch_on_delay_minutes:
+    name: "Bathroom switch on delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  bathroom_switch_off_delay_minutes:
+    name: "Bathroom switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  l1_switch_off_delay_minutes:
+    name: "L1 switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  boost_ventilation_minutes:
+    name: "Boost ventilation minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  filter_warning_weeks:
+    name: "Filter warning weeks" # "Filter Zähler Wochen"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  rf_high_time_short_minutes:
+    name: "RF high time short minutes" # 10
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  rf_high_time_long_minutes:
+    name: "RF high time long minutes" # 30
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  extractor_hood_switch_off_delay_minutes:
+    name: "Extractor hood switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration

--- a/comfoair_esp32_wemos_d1_mini32.yaml
+++ b/comfoair_esp32_wemos_d1_mini32.yaml
@@ -67,36 +67,36 @@ web_server:
   #   username: !secret web_server_username
   #   password: !secret web_server_password
   sorting_groups:
-    - id: sorting_group_10_temperatures
+    - id: sorting_group_temperatures
       name: "Comfo Actual Temperatures"
       sorting_weight: 10 # lower value gets sorted above higher. default value is 50
-    - id: sorting_group_20_bypass
+    - id: sorting_group_bypass
       name: "Comfo Bypass"
       sorting_weight: 20
-    - id: sorting_group_30_fan
+    - id: sorting_group_fan
       name: "Comfo Fans"
       sorting_weight: 30
-    - id: sorting_group_30_filter
+    - id: sorting_group_filter
       name: "Comfo Filter"
-      sorting_weight: 31
-    - id: sorting_group_30_statistics
-      name: "Comfo Statistics"
-      sorting_weight: 32
-    - id: sorting_group_35_Frost_Heat
-      name: "Comfo Heating and Frost Protection"
-      sorting_weight: 35
-    - id: sorting_group_40_configuration
-      name: "Comfo Configuration"
       sorting_weight: 40
-    - id: sorting_group_50_settings
-      name: "Comfo Parameter Settings"
+    - id: sorting_group_configuration
+      name: "Comfo Configuration"
       sorting_weight: 50
-    - id: sorting_group_60_setup
+    - id: sorting_group_setup
       name: "Comfo Parameter Setup"
       sorting_weight: 60
-    - id: sorting_group_70_features_present
-      name: "Comfo Features Present"
+    - id: sorting_group_statistics
+      name: "Comfo Statistics"
       sorting_weight: 70
+    - id: sorting_group_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 80
+    - id: sorting_group_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 90
+    - id: sorting_group_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 100
 
 # ### Native API Component ### (Home Assistant API)
 # <https://esphome.io/components/api>
@@ -127,7 +127,8 @@ mqtt:
 # <https://esphome.io/components/logger>
 logger:
   # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
-  level: DEBUG # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  level: VERY_VERBOSE # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  initial_level: INFO
 
 # ### Over-the-Air Updates ###
 # <https://esphome.io/components/ota/>
@@ -147,8 +148,8 @@ select:
     name: Select Level
     id: select_level
     options:
-      - "Auto"
-      - "Absent"
+      - "auto"
+      - "absent"
       - "low"
       - "medium"
       - "high"
@@ -240,7 +241,7 @@ button:
     id: filter_reset_button
     name: "Reset Filter"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
     on_press:
       then:
         lambda: "id(comfoair_climate).reset_filters();"
@@ -263,304 +264,304 @@ comfoair:
   type:
     name: "Type" # left
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   size:
     name: "Size" # small
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   size_select:
-    name: "unit_size"
+    name: "Size (unit_size)"
     web_server:
-      sorting_group_id: sorting_group_60_setup
+      sorting_group_id: sorting_group_setup
   intake_fan_speed:
     name: "Fan Supply air level" # %
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   exhaust_fan_speed:
     name: "Fan Return air level" # %
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   intake_fan_speed_rpm:
     name: "Fan Intake fan RPM" # RPM
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   exhaust_fan_speed_rpm:
     name: "Fan Exhaust fan RPM" # RPM
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   ventilation_level:
     name: "Ventilation level" # 0...3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   bypass_present:
     name: "Bypass present" # yes/no
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   bypass_valve:
     name: "Bypass valve" # %
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_valve_open:
     name: "Bypass open"  # yes/no
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   preheating_state:
     name: "Preheating state" # ON
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   outside_air_temperature:
     name: "T1 Outside temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   supply_air_temperature:
     name: "T2 Supply temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   return_air_temperature:
     name: "T3 Return temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   exhaust_air_temperature:
     name: "T4 Exhaust temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   enthalpy_temperature:
     name: "Enthalpy temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   ewt_temperature:
     name: "EWT temperature "
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   reheating_temperature:
     name: "Reheating temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   kitchen_hood_temperature:
     name: "Kitchen hood temperature"
     web_server:
-      sorting_group_id: sorting_group_10_temperatures
+      sorting_group_id: sorting_group_temperatures
   return_air_level:
     name: "Fan Return level" # m^3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   supply_air_level:
     name: "Fan Supply level" # m^3
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   supply_fan_active:
     name: "Fan Supply fan active" # yes/no
     web_server:
-      sorting_group_id: sorting_group_30_fan
+      sorting_group_id: sorting_group_fan
   filter_status:
     name: "Filter status" # Filter ok/Filter voll
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   enthalpy_present:
     name: "Enthalpy present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   ewt_present:
     name: "EWT present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   options_present:
     name: "Options present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   fireplace_present:
     name: "fireplace_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   kitchen_hood_present:
     name: "kitchen_hood_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   postheating_present:
     name: "postheating_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   postheating_pwm_mode_present:
     name: "postheating_pwm_mode_present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   preheating_present:
     name: "Preheating present" # OFF
     web_server:
-      sorting_group_id: sorting_group_70_features_present
+      sorting_group_id: sorting_group_features_present
   bypass_factor:
     name: "Bypass factor" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_step:
     name: "Bypass step" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_correction:
     name: "Bypass correction" # a number?
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   bypass_open_hours:
     name: "Bypass open hours" # h
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   preheating_hours:
     name: "Preheating hours" # 0
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level0_hours:
     name: "Level 0 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level1_hours:
     name: "Level 1 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level2_hours:
     name: "Level 2 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   level3_hours:
     name: "Level 3 hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   preheating_valve:
     name: "Preheating valve" # Unknown
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_active:
     name: "Frost protection active"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_hours:
     name: "Frost protection hours"
     web_server:
-      sorting_group_id: sorting_group_30_statistics
+      sorting_group_id: sorting_group_statistics
   frost_protection_minutes:
     name: "Frost protection minutes"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   frost_protection_level:
     name: "Frost protection level"
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   filter_hours:
     name: "Filter hours" # "Betriebsstunden Filter"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   motor_current_bypass:
     name: "Bypass motor current" # A
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   motor_current_preheating:
     name: "Motor current preheating" # 0.0
     web_server:
-      sorting_group_id: sorting_group_35_Frost_Heat
+      sorting_group_id: sorting_group_Frost_Heat
   summer_mode:
     name: "Summer mode"
     web_server:
-      sorting_group_id: sorting_group_20_bypass
+      sorting_group_id: sorting_group_bypass
   p10_active:
     name: "P10 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p11_active:
     name: "P11 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p12_active:
     name: "P12 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p13_active:
     name: "P13 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p14_active:
     name: "P14 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p15_active:
     name: "P15 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p16_active:
     name: "P16 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p17_active:
     name: "P17 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p18_active:
     name: "P18 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p19_active:
     name: "P19 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p90_active:
     name: "P90 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p91_active:
     name: "P91 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p92_active:
     name: "P92 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p93_active:
     name: "P93 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p94_active:
     name: "P94 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p95_active:
     name: "P95 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p96_active:
     name: "P96 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   p97_active:
     name: "P97 active"
     web_server:
-      sorting_group_id: sorting_group_50_settings
+      sorting_group_id: sorting_group_settings
   bathroom_switch_on_delay_minutes:
     name: "Bathroom switch on delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   bathroom_switch_off_delay_minutes:
     name: "Bathroom switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   l1_switch_off_delay_minutes:
     name: "L1 switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   boost_ventilation_minutes:
     name: "Boost ventilation minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   filter_warning_weeks:
     name: "Filter warning weeks" # "Filter Zähler Wochen"
     web_server:
-      sorting_group_id: sorting_group_30_filter
+      sorting_group_id: sorting_group_filter
   rf_high_time_short_minutes:
     name: "RF high time short minutes" # 10
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   rf_high_time_long_minutes:
     name: "RF high time long minutes" # 30
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration
   extractor_hood_switch_off_delay_minutes:
     name: "Extractor hood switch off delay minutes"
     web_server:
-      sorting_group_id: sorting_group_40_configuration
+      sorting_group_id: sorting_group_configuration

--- a/comfoair_esp32_wemos_d1_mini32.yaml
+++ b/comfoair_esp32_wemos_d1_mini32.yaml
@@ -1,0 +1,566 @@
+# ### Substitutions ###
+# <https://esphome.io/components/substitutions>
+substitutions:
+  node_name: comfoair # [a-z][0-9][_] max 24 characters, unique name per network!
+  device_name: "Zehnder ComfoAir 350"
+  node_comment: "ESPhome controller for ComfoAir 350" # Additional text information about this node. Only for display in UI.
+  ota_password: !secret comfoair_ota_password
+
+# ### Core configuration ###
+# <https://esphome.io/components/esphome>
+esphome:
+  name: ${node_name}
+  friendly_name: "${device_name}"
+  comment: ${node_comment}
+  area: lab #livingroom
+  project:
+    name: "parsley.comfoair" # author_name.project_name
+    version: "1.1.0"
+  # debug_scheduler: false
+  # on_boot:
+  # on_loop:
+
+# ### Supported Microcontrollers ###
+# <https://esphome.io/components/esp32>
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+# ----- software & libraries -----
+
+# ----- external_components -----
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/parsley/esphome-comfoair
+    components: [comfoair]
+
+# ----- Communication connections (wifi, webserver, HomeAssistent-api, mqtt) -----
+
+# ### Network Hardware ###
+# <https://esphome.io/components/wifi>
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: ${node_name}-setup
+    password: !secret wifi_fallback_ap_key
+  # reboot_timeout: 0s
+  # power_save_mode: none # NONE (least power saving, Default for ESP8266), LIGHT (Default for ESP32), HIGH (most power saving)
+
+# ### Captive Portal ###
+# Enable captive portal on fallback hotspot (in case wifi connection fails)
+# <https://esphome.io/components/captive_portal>
+captive_portal:
+
+# ### Management and Monitoring ###
+# <https://esphome.io/components/web_server>
+web_server:
+  port: 80
+  ota: false
+  local: true
+  version: 3
+  # auth:
+  #   username: !secret web_server_username
+  #   password: !secret web_server_password
+  sorting_groups:
+    - id: sorting_group_10_temperatures
+      name: "Comfo Actual Temperatures"
+      sorting_weight: 10 # lower value gets sorted above higher. default value is 50
+    - id: sorting_group_20_bypass
+      name: "Comfo Bypass"
+      sorting_weight: 20
+    - id: sorting_group_30_fan
+      name: "Comfo Fans"
+      sorting_weight: 30
+    - id: sorting_group_30_filter
+      name: "Comfo Filter"
+      sorting_weight: 31
+    - id: sorting_group_30_statistics
+      name: "Comfo Statistics"
+      sorting_weight: 32
+    - id: sorting_group_35_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 35
+    - id: sorting_group_40_configuration
+      name: "Comfo Configuration"
+      sorting_weight: 40
+    - id: sorting_group_50_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 50
+    - id: sorting_group_60_setup
+      name: "Comfo Parameter Setup"
+      sorting_weight: 60
+    - id: sorting_group_70_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 70
+
+# ### Native API Component ### (Home Assistant API)
+# <https://esphome.io/components/api>
+# api:
+#   encryption:
+#     key: !secret comfoair_api_encryption_key
+#   reboot_timeout: 0s # disable reboot (0s), default: 15min
+#   custom_services: true
+
+# ### MQTT Client Component ###
+# <https://esphome.io/components/mqtt>
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  port: 1883
+  # clean_session: false # default
+  # discover_ip: false
+  # discovery: false
+  # discovery_retain: false
+  # reboot_timeout: 0s
+  # topic_prefix:
+  # log_topic:
+
+# Programming and debugging
+
+# ### Logger Component ###
+# <https://esphome.io/components/logger>
+logger:
+  # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
+  level: DEBUG # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+
+# ### Over-the-Air Updates ###
+# <https://esphome.io/components/ota/>
+ota:
+  - platform: esphome # <https://esphome.io/components/ota/esphome>
+    password: ${ota_password}
+
+# Select
+# Logger Select - Example configuration entry
+# <https://esphome.io/components/select/logger>
+# select select_level:
+# <https://github.com/esphome/feature-requests/issues/3151>
+select:
+  - platform: logger
+    name: "Logger select"
+  - platform: template
+    name: Select Level
+    id: select_level
+    options:
+      - "Auto"
+      - "Absent"
+      - "low"
+      - "medium"
+      - "high"
+    initial_option: "medium"
+    optimistic: True
+    on_value:
+      then:
+        - lambda: |-
+            switch(i){
+            case 0:
+              id(comfoair_climate).set_level(0);
+              break;
+            case 1:
+              id(comfoair_climate).set_level(1);
+              break;
+            case 2:
+              id(comfoair_climate).set_level(2);
+              break;
+            case 3:
+              id(comfoair_climate).set_level(3);
+              break;
+            case 4:
+              id(comfoair_climate).set_level(4);
+              break;
+            default:
+              id(comfoair_climate).set_level(1);
+            }
+
+# sensors / inputs / outputs
+
+# http_request:
+
+# output:
+#   - platform: gpio
+#     id: orange_led_out
+#     pin: GPIO18
+#   - platform: gpio
+#     id: green_led_out
+#     pin: GPIO19
+
+# interval:
+#   - interval: 1s
+#     then:
+#       if:
+#         condition:
+#           wifi.connected:
+#         then:
+#           - output.turn_off: green_led_out
+#         else:
+#           - output.turn_on: green_led_out
+#           - delay: 500ms
+#           - output.turn_off: green_led_out
+#   - interval: 500ms
+#     then:
+#       if:
+#         condition:
+#           api.connected:
+#         then:
+#           - output.turn_off: orange_led_out
+#         else:
+#           - if:
+#               condition:
+#                 wifi.connected
+#               then:
+#                 - output.turn_on: orange_led_out
+#                 - delay: 250ms
+#                 - output.turn_off: orange_led_out
+#               else:
+#                 - output.turn_off: orange_led_out
+
+sensor:
+  - platform: uptime
+    name: "Uptime"
+  - platform: wifi_signal
+    name: "WiFi Signal Strength"
+    update_interval: 60s
+
+# binary_sensor:
+
+switch:
+  - platform: factory_reset
+    name: Restart with Factory Default Settings
+
+button:
+  - platform: restart
+    id: reset_button
+    name: "Reset ESP32 Comfoair Adapter"
+  - platform: template
+    id: filter_reset_button
+    name: "Reset Filter"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+    on_press:
+      then:
+        lambda: "id(comfoair_climate).reset_filters();"
+
+text_sensor:
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+uart:
+  id: uart_bus
+  baud_rate: 9600
+  tx_pin: GPIO17 # U2TX
+  rx_pin: GPIO16 # U2RX
+
+comfoair:
+  id: comfoair_climate
+  name: "${node_name}"
+  uart_id: uart_bus
+  type:
+    name: "Type" # left
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  size:
+    name: "Size" # small
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  size_select:
+    name: "unit_size"
+    web_server:
+      sorting_group_id: sorting_group_60_setup
+  intake_fan_speed:
+    name: "Fan Supply air level" # %
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  exhaust_fan_speed:
+    name: "Fan Return air level" # %
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  intake_fan_speed_rpm:
+    name: "Fan Intake fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  exhaust_fan_speed_rpm:
+    name: "Fan Exhaust fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  ventilation_level:
+    name: "Ventilation level" # 0...3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  bypass_present:
+    name: "Bypass present" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  bypass_valve:
+    name: "Bypass valve" # %
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_valve_open:
+    name: "Bypass open"  # yes/no
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  preheating_state:
+    name: "Preheating state" # ON
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  outside_air_temperature:
+    name: "T1 Outside temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  supply_air_temperature:
+    name: "T2 Supply temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  return_air_temperature:
+    name: "T3 Return temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  exhaust_air_temperature:
+    name: "T4 Exhaust temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  enthalpy_temperature:
+    name: "Enthalpy temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  ewt_temperature:
+    name: "EWT temperature "
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  reheating_temperature:
+    name: "Reheating temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  kitchen_hood_temperature:
+    name: "Kitchen hood temperature"
+    web_server:
+      sorting_group_id: sorting_group_10_temperatures
+  return_air_level:
+    name: "Fan Return level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  supply_air_level:
+    name: "Fan Supply level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  supply_fan_active:
+    name: "Fan Supply fan active" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_30_fan
+  filter_status:
+    name: "Filter status" # Filter ok/Filter voll
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  enthalpy_present:
+    name: "Enthalpy present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  ewt_present:
+    name: "EWT present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  options_present:
+    name: "Options present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  fireplace_present:
+    name: "fireplace_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  kitchen_hood_present:
+    name: "kitchen_hood_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  postheating_present:
+    name: "postheating_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  postheating_pwm_mode_present:
+    name: "postheating_pwm_mode_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  preheating_present:
+    name: "Preheating present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_70_features_present
+  bypass_factor:
+    name: "Bypass factor" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_step:
+    name: "Bypass step" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_correction:
+    name: "Bypass correction" # a number?
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  bypass_open_hours:
+    name: "Bypass open hours" # h
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  preheating_hours:
+    name: "Preheating hours" # 0
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level0_hours:
+    name: "Level 0 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level1_hours:
+    name: "Level 1 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level2_hours:
+    name: "Level 2 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  level3_hours:
+    name: "Level 3 hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  preheating_valve:
+    name: "Preheating valve" # Unknown
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_active:
+    name: "Frost protection active"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_hours:
+    name: "Frost protection hours"
+    web_server:
+      sorting_group_id: sorting_group_30_statistics
+  frost_protection_minutes:
+    name: "Frost protection minutes"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  frost_protection_level:
+    name: "Frost protection level"
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  filter_hours:
+    name: "Filter hours" # "Betriebsstunden Filter"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  motor_current_bypass:
+    name: "Bypass motor current" # A
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  motor_current_preheating:
+    name: "Motor current preheating" # 0.0
+    web_server:
+      sorting_group_id: sorting_group_35_Frost_Heat
+  summer_mode:
+    name: "Summer mode"
+    web_server:
+      sorting_group_id: sorting_group_20_bypass
+  p10_active:
+    name: "P10 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p11_active:
+    name: "P11 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p12_active:
+    name: "P12 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p13_active:
+    name: "P13 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p14_active:
+    name: "P14 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p15_active:
+    name: "P15 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p16_active:
+    name: "P16 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p17_active:
+    name: "P17 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p18_active:
+    name: "P18 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p19_active:
+    name: "P19 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p90_active:
+    name: "P90 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p91_active:
+    name: "P91 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p92_active:
+    name: "P92 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p93_active:
+    name: "P93 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p94_active:
+    name: "P94 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p95_active:
+    name: "P95 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p96_active:
+    name: "P96 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  p97_active:
+    name: "P97 active"
+    web_server:
+      sorting_group_id: sorting_group_50_settings
+  bathroom_switch_on_delay_minutes:
+    name: "Bathroom switch on delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  bathroom_switch_off_delay_minutes:
+    name: "Bathroom switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  l1_switch_off_delay_minutes:
+    name: "L1 switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  boost_ventilation_minutes:
+    name: "Boost ventilation minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  filter_warning_weeks:
+    name: "Filter warning weeks" # "Filter Zähler Wochen"
+    web_server:
+      sorting_group_id: sorting_group_30_filter
+  rf_high_time_short_minutes:
+    name: "RF high time short minutes" # 10
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  rf_high_time_long_minutes:
+    name: "RF high time long minutes" # 30
+    web_server:
+      sorting_group_id: sorting_group_40_configuration
+  extractor_hood_switch_off_delay_minutes:
+    name: "Extractor hood switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_40_configuration

--- a/comfoair_esp32_wemos_d1_mini32.yaml
+++ b/comfoair_esp32_wemos_d1_mini32.yaml
@@ -1,0 +1,575 @@
+# ### Substitutions ###
+# <https://esphome.io/components/substitutions>
+substitutions:
+  node_name: comfoair # [a-z][0-9][_] max 24 characters, unique name per network!
+  device_name: "Zehnder ComfoAir 350"
+  node_comment: "ESPhome controller for ComfoAir 350" # Additional text information about this node. Only for display in UI.
+  ota_password: !secret comfoair_ota_password
+
+# ### Core configuration ###
+# <https://esphome.io/components/esphome>
+esphome:
+  name: ${node_name}
+  friendly_name: "${device_name}"
+  comment: ${node_comment}
+  area: lab #livingroom
+  project:
+    name: "wichers.comfoair" # author_name.project_name
+    version: "1.1.0"
+  # debug_scheduler: false
+  # on_boot:
+  # on_loop:
+
+# ### Supported Microcontrollers ###
+# <https://esphome.io/components/esp32>
+esp32:
+  board: wemos_d1_mini32
+  framework:
+    type: esp-idf
+
+# ----- software & libraries -----
+
+# ----- external_components -----
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/wichers/esphome-comfoair
+    components: [comfoair]
+
+# ----- Communication connections (wifi, webserver, HomeAssistent-api, mqtt) -----
+
+# ### Network Hardware ###
+# <https://esphome.io/components/wifi>
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  # Enable fallback hotspot in case wifi connection fails
+  ap:
+    ssid: ${node_name}-setup
+    password: !secret wifi_fallback_ap_key
+  # reboot_timeout: 0s
+  # power_save_mode: none # NONE (least power saving, Default for ESP8266), LIGHT (Default for ESP32), HIGH (most power saving)
+
+# ### Captive Portal ###
+# Enable captive portal on fallback hotspot (in case wifi connection fails)
+# <https://esphome.io/components/captive_portal>
+captive_portal:
+
+# ### Management and Monitoring ###
+# <https://esphome.io/components/web_server>
+web_server:
+  port: 80
+  ota: false
+  local: true
+  version: 3
+  # auth:
+  #   username: !secret web_server_username
+  #   password: !secret web_server_password
+  sorting_groups:
+    - id: sorting_group_temperatures
+      name: "Comfo Actual Temperatures"
+      sorting_weight: 10 # lower value gets sorted above higher. default value is 50
+    - id: sorting_group_bypass
+      name: "Comfo Bypass"
+      sorting_weight: 20
+    - id: sorting_group_fan
+      name: "Comfo Fans"
+      sorting_weight: 30
+    - id: sorting_group_filter
+      name: "Comfo Filter"
+      sorting_weight: 40
+    - id: sorting_group_configuration
+      name: "Comfo Configuration"
+      sorting_weight: 50
+    - id: sorting_group_setup
+      name: "Comfo Parameter Setup"
+      sorting_weight: 60
+    - id: sorting_group_statistics
+      name: "Comfo Statistics"
+      sorting_weight: 70
+    - id: sorting_group_Frost_Heat
+      name: "Comfo Heating and Frost Protection"
+      sorting_weight: 80
+    - id: sorting_group_settings
+      name: "Comfo Parameter Settings"
+      sorting_weight: 90
+    - id: sorting_group_features_present
+      name: "Comfo Features Present"
+      sorting_weight: 100
+
+# ### Native API Component ### (Home Assistant API)
+# <https://esphome.io/components/api>
+# api:
+#   encryption:
+#     key: !secret comfoair_api_encryption_key
+#   reboot_timeout: 0s # disable reboot (0s), default: 15min
+#   custom_services: true
+
+# ### MQTT Client Component ###
+# <https://esphome.io/components/mqtt>
+mqtt:
+  broker: !secret mqtt_host
+  username: !secret mqtt_username
+  password: !secret mqtt_password
+  port: 1883
+  # clean_session: false # default
+  # discover_ip: false
+  # discovery: false
+  # discovery_retain: false
+  # reboot_timeout: 0s
+  # topic_prefix:
+  # log_topic:
+
+# Programming and debugging
+
+# ### Logger Component ###
+# <https://esphome.io/components/logger>
+logger:
+  # baud_rate: 115200 # serial UART baud_rate. 0 = disable logging via UART
+  level: VERY_VERBOSE # VERY_VERBOSE, VERBOSE, DEBUG, INFO, WARN, ERROR, NONE
+  initial_level: INFO
+
+# ### Over-the-Air Updates ###
+# <https://esphome.io/components/ota/>
+ota:
+  - platform: esphome # <https://esphome.io/components/ota/esphome>
+    password: ${ota_password}
+
+# Select
+# Logger Select - Example configuration entry
+# <https://esphome.io/components/select/logger>
+# select select_level:
+# <https://github.com/esphome/feature-requests/issues/3151>
+select:
+  - platform: logger
+    name: "Logger select"
+  - platform: template
+    name: Select Level
+    id: select_level
+    options:
+      - "auto"
+      - "absent"
+      - "low"
+      - "medium"
+      - "high"
+    initial_option: "medium"
+    optimistic: True
+    on_value:
+      then:
+        - lambda: |-
+            switch(i){
+            case 0:
+              id(comfoair_climate).set_level(0);
+              break;
+            case 1:
+              id(comfoair_climate).set_level(1);
+              break;
+            case 2:
+              id(comfoair_climate).set_level(2);
+              break;
+            case 3:
+              id(comfoair_climate).set_level(3);
+              break;
+            case 4:
+              id(comfoair_climate).set_level(4);
+              break;
+            default:
+              id(comfoair_climate).set_level(1);
+            }
+
+# sensors / inputs / outputs
+
+# http_request:
+
+# output:
+#   - platform: gpio
+#     id: orange_led_out
+#     pin: GPIO18
+#   - platform: gpio
+#     id: green_led_out
+#     pin: GPIO19
+
+# interval:
+#   - interval: 1s
+#     then:
+#       if:
+#         condition:
+#           wifi.connected:
+#         then:
+#           - output.turn_off: green_led_out
+#         else:
+#           - output.turn_on: green_led_out
+#           - delay: 500ms
+#           - output.turn_off: green_led_out
+#   - interval: 500ms
+#     then:
+#       if:
+#         condition:
+#           api.connected:
+#         then:
+#           - output.turn_off: orange_led_out
+#         else:
+#           - if:
+#               condition:
+#                 wifi.connected
+#               then:
+#                 - output.turn_on: orange_led_out
+#                 - delay: 250ms
+#                 - output.turn_off: orange_led_out
+#               else:
+#                 - output.turn_off: orange_led_out
+
+sensor:
+  - platform: uptime
+    name: "Uptime"
+  - platform: wifi_signal
+    name: "WiFi Signal Strength"
+    update_interval: 60s
+
+# binary_sensor:
+
+switch:
+  - platform: factory_reset
+    name: Restart with Factory Default Settings
+
+button:
+  - platform: restart
+    id: reset_button
+    name: "Reset ESP32 Comfoair Adapter"
+  - platform: template
+    id: filter_reset_button
+    name: "Reset Filter"
+    web_server:
+      sorting_group_id: sorting_group_filter
+    on_press:
+      then:
+        lambda: "id(comfoair_climate).reset_filters();"
+
+text_sensor:
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+
+uart:
+  id: uart_bus
+  baud_rate: 9600
+  tx_pin: GPIO17 # U2TX
+  rx_pin: GPIO16 # U2RX
+
+comfoair:
+  id: comfoair_climate
+  name: "${node_name}"
+  uart_id: uart_bus
+  type:
+    name: "Type" # left
+    web_server:
+      sorting_group_id: sorting_group_setup
+  size:
+    name: "Size" # small
+    web_server:
+      sorting_group_id: sorting_group_setup
+  size_select:
+    name: "Size (unit_size)"
+    web_server:
+      sorting_group_id: sorting_group_setup
+  intake_fan_speed:
+    name: "Fan Supply air level" # %
+    web_server:
+      sorting_group_id: sorting_group_fan
+  exhaust_fan_speed:
+    name: "Fan Return air level" # %
+    web_server:
+      sorting_group_id: sorting_group_fan
+  intake_fan_speed_rpm:
+    name: "Fan Intake fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_fan
+  exhaust_fan_speed_rpm:
+    name: "Fan Exhaust fan RPM" # RPM
+    web_server:
+      sorting_group_id: sorting_group_fan
+  ventilation_level:
+    name: "Ventilation level" # 0...3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  bypass_present:
+    name: "Bypass present" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  bypass_valve:
+    name: "Bypass valve" # %
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_valve_open:
+    name: "Bypass open"  # yes/no
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  preheating_state:
+    name: "Preheating state" # ON
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  preheating_active:
+    name: "Preheating active"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  outside_air_temperature:
+    name: "T1 Outside temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  supply_air_temperature:
+    name: "T2 Supply temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  return_air_temperature:
+    name: "T3 Return temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  exhaust_air_temperature:
+    name: "T4 Exhaust temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  enthalpy_temperature:
+    name: "Enthalpy temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  ewt_temperature:
+    name: "EWT temperature "
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  reheating_temperature:
+    name: "Reheating temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  kitchen_hood_temperature:
+    name: "Kitchen hood temperature"
+    web_server:
+      sorting_group_id: sorting_group_temperatures
+  return_air_level:
+    name: "Fan Return level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  supply_air_level:
+    name: "Fan Supply level" # m^3
+    web_server:
+      sorting_group_id: sorting_group_fan
+  supply_fan_active:
+    name: "Fan Supply fan active" # yes/no
+    web_server:
+      sorting_group_id: sorting_group_fan
+  filter_status:
+    name: "Filter status" # Filter ok/Filter voll
+    web_server:
+      sorting_group_id: sorting_group_filter
+  filter_status_full:
+    name: "Filter full"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  enthalpy_present:
+    name: "Enthalpy present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  ewt_present:
+    name: "EWT present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  options_present:
+    name: "Options present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  fireplace_present:
+    name: "fireplace_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  kitchen_hood_present:
+    name: "kitchen_hood_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  postheating_present:
+    name: "postheating_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  postheating_pwm_mode_present:
+    name: "postheating_pwm_mode_present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  preheating_present:
+    name: "Preheating present" # OFF
+    web_server:
+      sorting_group_id: sorting_group_features_present
+  bypass_factor:
+    name: "Bypass factor" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_step:
+    name: "Bypass step" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_correction:
+    name: "Bypass correction" # a number?
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  bypass_open_hours:
+    name: "Bypass open hours" # h
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  preheating_hours:
+    name: "Preheating hours" # 0
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level0_hours:
+    name: "Level 0 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level1_hours:
+    name: "Level 1 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level2_hours:
+    name: "Level 2 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  level3_hours:
+    name: "Level 3 hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  preheating_valve:
+    name: "Preheating valve" # Unknown
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_active:
+    name: "Frost protection active"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_hours:
+    name: "Frost protection hours"
+    web_server:
+      sorting_group_id: sorting_group_statistics
+  frost_protection_minutes:
+    name: "Frost protection minutes"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  frost_protection_level:
+    name: "Frost protection level"
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  filter_hours:
+    name: "Filter hours" # "Betriebsstunden Filter"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  motor_current_bypass:
+    name: "Bypass motor current" # A
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  motor_current_preheating:
+    name: "Motor current preheating" # 0.0
+    web_server:
+      sorting_group_id: sorting_group_Frost_Heat
+  summer_mode:
+    name: "Summer mode"
+    web_server:
+      sorting_group_id: sorting_group_bypass
+  p10_active:
+    name: "P10 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p11_active:
+    name: "P11 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p12_active:
+    name: "P12 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p13_active:
+    name: "P13 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p14_active:
+    name: "P14 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p15_active:
+    name: "P15 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p16_active:
+    name: "P16 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p17_active:
+    name: "P17 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p18_active:
+    name: "P18 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p19_active:
+    name: "P19 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p90_active:
+    name: "P90 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p91_active:
+    name: "P91 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p92_active:
+    name: "P92 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p93_active:
+    name: "P93 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p94_active:
+    name: "P94 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p95_active:
+    name: "P95 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p96_active:
+    name: "P96 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  p97_active:
+    name: "P97 active"
+    web_server:
+      sorting_group_id: sorting_group_settings
+  bathroom_switch_on_delay_minutes:
+    name: "Bathroom switch on delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  bathroom_switch_off_delay_minutes:
+    name: "Bathroom switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  l1_switch_off_delay_minutes:
+    name: "L1 switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  boost_ventilation_minutes:
+    name: "Boost ventilation minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  filter_warning_weeks:
+    name: "Filter warning weeks" # "Filter Zähler Wochen"
+    web_server:
+      sorting_group_id: sorting_group_filter
+  rf_high_time_short_minutes:
+    name: "RF high time short minutes" # 10
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  rf_high_time_long_minutes:
+    name: "RF high time long minutes" # 30
+    web_server:
+      sorting_group_id: sorting_group_configuration
+  extractor_hood_switch_off_delay_minutes:
+    name: "Extractor hood switch off delay minutes"
+    web_server:
+      sorting_group_id: sorting_group_configuration

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -522,14 +522,13 @@ comfoair_sensors_schemas = cv.Schema(
 )
 
 CONFIG_SCHEMA = (
-  climate.climate_schema(ComfoAirComponent)
-  .extend(
-    {
-      cv.Required(REQUIRED_KEY_NAME): cv.string,
-    }
-  )
-  .extend(uart.UART_DEVICE_SCHEMA)
-  .extend(comfoair_sensors_schemas)
+    climate.climate_schema(ComfoAirComponent).extend(
+        {
+            cv.Required(REQUIRED_KEY_NAME): cv.string,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(comfoair_sensors_schemas)
 )
 
 def to_code(config):

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -2,19 +2,51 @@
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import binary_sensor, sensor, text_sensor, uart, climate, select, number, button
-from esphome.const import (CONF_ID, CONF_UART_ID, DEVICE_CLASS_CURRENT,
-                           DEVICE_CLASS_EMPTY, DEVICE_CLASS_SPEED,
-                           DEVICE_CLASS_TEMPERATURE, DEVICE_CLASS_VOLUME,
-                           STATE_CLASS_MEASUREMENT, UNIT_AMPERE, UNIT_CELSIUS,
-                           UNIT_CUBIC_METER, UNIT_HOUR, UNIT_MINUTE,
-                           UNIT_PERCENT, UNIT_REVOLUTIONS_PER_MINUTE, CONF_DISABLED_BY_DEFAULT,
-                           ICON_FAN, CONF_ICON, CONF_INITIAL_VALUE, CONF_MIN_VALUE, CONF_MAX_VALUE, CONF_STEP)
+from esphome.components import (
+    binary_sensor,
+    button,
+    climate,
+    number,
+    select,
+    sensor,
+    text_sensor,
+    uart,
+)
+from esphome.const import (
+    CONF_DISABLED_BY_DEFAULT,
+    CONF_ICON,
+    CONF_ID,
+    CONF_INITIAL_VALUE,
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_STEP,
+    CONF_UART_ID,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_SPEED,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLUME,
+    ICON_FAN,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_CUBIC_METER,
+    UNIT_HOUR,
+    UNIT_MINUTE,
+    UNIT_PERCENT,
+    UNIT_REVOLUTIONS_PER_MINUTE,
+)
 
 comfoair_ns = cg.esphome_ns.namespace("comfoair")
-ComfoAirComponent = comfoair_ns.class_('ComfoAirComponent', climate.Climate, cg.Component, uart.UARTDevice)
+
+# ESPHome codegen handles intentionally mirror their generated C++ class names.
+# pylint: disable=invalid-name
+ComfoAirComponent = comfoair_ns.class_(
+    "ComfoAirComponent", climate.Climate, cg.Component, uart.UARTDevice
+)
 ComfoAirNumber = comfoair_ns.class_("ComfoAirNumber", number.Number)
 ComfoAirSyncButton = comfoair_ns.class_("ComfoAirSyncButton", button.Button)
+# pylint: enable=invalid-name
 
 DEPENDENCIES = ["uart"]
 AUTO_LOAD = ["sensor", "climate", "binary_sensor", "text_sensor", "select", "number", "button"]
@@ -218,7 +250,10 @@ helper_comfoair = {
     ],
 }
 
-ComfoAirSizeSelect = comfoair_ns.class_("ComfoAirSizeSelect", select.Select)
+# This codegen handle also mirrors its generated C++ class name.
+ComfoAirSizeSelect = comfoair_ns.class_(  # pylint: disable=invalid-name
+    "ComfoAirSizeSelect", select.Select
+)
 
 comfoair_sensors_schemas = cv.Schema(
     {

--- a/components/comfoair/__init__.py
+++ b/components/comfoair/__init__.py
@@ -644,14 +644,13 @@ comfoair_sensors_schemas = cv.Schema(
 )
 
 CONFIG_SCHEMA = (
-  climate.climate_schema(ComfoAirComponent)
-  .extend(
-    {
-      cv.Required(REQUIRED_KEY_NAME): cv.string,
-    }
-  )
-  .extend(uart.UART_DEVICE_SCHEMA)
-  .extend(comfoair_sensors_schemas)
+    climate.climate_schema(ComfoAirComponent).extend(
+        {
+            cv.Required(REQUIRED_KEY_NAME): cv.string,
+        }
+    )
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(comfoair_sensors_schemas)
 )
 
 def to_code(config):

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -16,6 +16,22 @@ namespace esphome
   namespace comfoair
   {
 
+    // These are the possible status of the two receive functions for CA and CS
+    typedef enum
+    {
+      RX_STATUS_DEFAULT,                     // default (should not happen. coding error?)
+      RX_STATUS_RECEIVED_ACK,                // ACK received
+      RX_STATUS_RECEIVED_MESSAGE,            // message received
+      RX_STATUS_RECEIVED_INVALID_MESSAGE,    // invalid message received (rx error)
+      RX_STATUS_RECEIVED_START_OF_MESSAGE,   // found rx-Start and adjusted buffer accordingly (just 4 info. no error.)
+      RX_STATUS_WRAPPED_BUFFER_INDEX         // wrapped buffer index (just 4 info. no error.)
+    } rx_status;
+
+    static const uint8_t COMFOAIR_MIN_SUPPORTED_TEMP  = 12;
+    static const uint8_t COMFOAIR_MAX_SUPPORTED_TEMP  = 29;
+    static const float   COMFOAIR_SUPPORTED_TEMP_STEP = 0.5f;
+    static const uint8_t MAX_MESSAGE_SIZE = 70U;
+
     static const char *TAG = "comfoair";
 
     class ComfoAirComponent;
@@ -37,32 +53,35 @@ namespace esphome
       friend class ComfoAirSizeSelect;
 
     public:
-      // Poll every 600ms
+
+      // Poll every 2000ms (previously 600ms)
       ComfoAirComponent() : Climate(),
-                            PollingComponent(600),
+                            PollingComponent(2000),
                             UARTDevice() {}
 
-      /// Return the traits of this controller.
+      // Return the traits of this controller.
       climate::ClimateTraits traits() override
       {
         auto traits = climate::ClimateTraits();
-    traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+        traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
         traits.set_supported_modes({climate::CLIMATE_MODE_FAN_ONLY});
-    traits.clear_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
-    traits.clear_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
-        traits.set_visual_min_temperature(12);
-        traits.set_visual_max_temperature(29);
-        traits.set_visual_temperature_step(1);
-    traits.set_supported_fan_modes({
-      climate::CLIMATE_FAN_LOW,
-      climate::CLIMATE_FAN_MEDIUM,
-      climate::CLIMATE_FAN_HIGH,
-      climate::CLIMATE_FAN_OFF,
-    });
+        traits.clear_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
+        traits.set_supported_presets({climate::CLIMATE_PRESET_HOME});
+        traits.clear_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
+        traits.set_visual_min_temperature(COMFOAIR_MIN_SUPPORTED_TEMP);
+        traits.set_visual_max_temperature(COMFOAIR_MAX_SUPPORTED_TEMP);
+        traits.set_visual_temperature_step(COMFOAIR_SUPPORTED_TEMP_STEP);
+        traits.set_supported_fan_modes({
+          climate::CLIMATE_FAN_AUTO,
+          climate::CLIMATE_FAN_LOW,
+          climate::CLIMATE_FAN_MEDIUM,
+          climate::CLIMATE_FAN_HIGH,
+          climate::CLIMATE_FAN_OFF,
+        });
         return traits;
       }
 
-      /// Override control to change settings of the climate device.
+      // Override control to change settings of the climate device.
       void control(const climate::ClimateCall &call) override
       {
         if (call.get_fan_mode().has_value())
@@ -84,11 +103,14 @@ namespace esphome
           case climate::CLIMATE_FAN_OFF:
             level = 0x01;
             break;
-        case climate::CLIMATE_FAN_ON:
-        case climate::CLIMATE_FAN_MIDDLE:
-        case climate::CLIMATE_FAN_DIFFUSE:
-        default:
-          level = -1;
+          case climate::CLIMATE_FAN_AUTO:
+            level = 0x00;
+            break;
+          case climate::CLIMATE_FAN_ON:
+          case climate::CLIMATE_FAN_MIDDLE:
+          case climate::CLIMATE_FAN_DIFFUSE:
+          default:
+            level = -1;
             break;
           }
 
@@ -131,6 +153,7 @@ namespace esphome
 
       void update() override
       {
+        ESP_LOGD(TAG, "Component update: %d", update_counter_);
         switch (update_counter_)
         {
         case -4:
@@ -175,55 +198,97 @@ namespace esphome
         case 9:
           get_time_delay_();
           break;
+        default:
+          ESP_LOGI(TAG, "Component update: %d", update_counter_);
+          break;
         }
 
         update_counter_++;
-        if (update_counter_ > num_update_counter_elements_)
+        if (update_counter_ > 9) // num_update_counter_elements_
+        {
           update_counter_ = 0;
+        }
       }
 
       void loop() override
       {
+        /*
+        TX:
+        1. Build TX-array:
+          - 2 Byte Command
+          - 1 Byte Size = amount of data bytes (0...n)
+          - 0...n data bytes = payload data (without doubled 0x07 bytes yet)
+        2. Calculate and append checksum across TX-array.
+        3. transmit function:
+          - transmit 2 Byte "START" (0x07 0xF0)
+          - transmit TX-array
+            - transmit byte 1 to byte 3
+            - transmit byte 4 to byte [3.byte + 3] while transmitting each 0x07 twice.
+            - transmit byte [3.byte + 4].
+          - transmit 2 Byte "STOP" (0x07 0x0F)
+
+        RX:
+        1. read uart byte by byte into RX-array
+          - search for ACK (0x07 0xF3) -> announce new ACK
+          - search for START (0x07 0xF0) and STOP (0x07 0x0F) -> announce new message
+        2. remove START, STOP and doubled 0x07 from new RX-array to get clean data.
+        3. calculate and verify checksum of new message.
+          - send ACK?
+        4. process RX data
+        */
+
+        // CA350
+        // caRxSerial();       // receive ACKs and messages from CA350
+
         while (available() != 0)
         {
-          read_byte(&data_[data_index_]);
-          auto check = check_byte_();
-          if (!check.has_value())
-          {
+          uint8_t rx_byte_u8;
 
-            // finished
-            if (data_[COMMAND_ID_ACK] != COMMAND_ACK)
-            {
-              parse_data_();
-            }
-            data_index_ = 0;
-          }
-          else if (!*check)
+          // fetch byte for RX buffer and process it by readRx()
+          read_byte(&rx_byte_u8);
+
+          switch (checkRx_(caRxBuffer_au8, &caRxIdx_u8, rx_byte_u8))
           {
-            // wrong data
-            ESP_LOGV(TAG, "Byte %i of received data frame is invalid.", data_index_);
-            data_index_ = 0;
-          }
-          else
-          {
-            // next byte
-            data_index_++;
+          case RX_STATUS_DEFAULT:
+            break;
+          case RX_STATUS_RECEIVED_ACK:
+            ESP_LOGVV(TAG, "RX: ACK");
+            // caProcessNewACK(); // do something if an ACK is received
+            break;
+          case RX_STATUS_RECEIVED_MESSAGE:
+            ESP_LOGVV(TAG, "RX: message cmd: %02X", caRxBuffer_au8[1]);
+            // acknowledge message
+            txACK_();
+            // at this point caRxBuffer_au8 consists of
+            // 2-byte command, length, data and checksum.
+            // caProcessNewData(caRxBuffer); // do something with received message
+            parseRxMessage_(caRxBuffer_au8);
+            break;
+          case RX_STATUS_RECEIVED_INVALID_MESSAGE:
+            ESP_LOGW(TAG, "RX: Invalid checksum (from CA350).");
+            break;
+          case RX_STATUS_RECEIVED_START_OF_MESSAGE:
+          case RX_STATUS_WRAPPED_BUFFER_INDEX:
+          default:
+            break;
           }
         }
+
+        // ComfoSense
+        // csRxSerial();       // receive ACKs and messages from ComfoSense
+
       }
 
       float get_setup_priority() const override { return setup_priority::DATA; }
 
-      void error_reset(void)
+      void reset_errors(void)
       {
-        uint8_t reset_cmd[4] = {1, 0, 0, 0};
-        write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
+        reset_errors_(false, true);
       }
 
-      void filter_reset(void)
+      void reset_filters(void)
       {
-        uint8_t reset_cmd[4] = {0, 0, 0, 1};
-        write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
+        reset_errors_(true, false);
       }
 
       void set_name(const char *value) { name = value; }
@@ -236,10 +301,28 @@ namespace esphome
       bool set_unit_size(uint8_t raw_size);
       void set_size_select(ComfoAirSizeSelect *size_select);
 
+      void set_level(int level)
+      {
+        set_level_(level);
+      }
+      void set_comfort_temperature(float temperature)
+      {
+        void set_comfort_temperature_(float temperature);
+      }
+
     protected:
+
+      // --- setter ---
+      
+      void reset_errors_(bool filters, bool errors)
+      {
+        uint8_t reset_cmd[CMD_RESET_AND_SELF_TEST_LENGTH] = {errors ? (uint8_t)1 : (uint8_t)0, 0, 0, filters ? (uint8_t)1 : (uint8_t)0};
+        write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
+      }
+
       void set_level_(int level)
       {
-        if (level < 0 || level > 5)
+        if (level < 0 || level > 4)
         {
           ESP_LOGI(TAG, "Ignoring invalid level request: %i", level);
           return;
@@ -247,14 +330,15 @@ namespace esphome
 
         ESP_LOGI(TAG, "Setting level to: %i", level);
         {
-          uint8_t command[1] = {(uint8_t)level};
+          uint8_t command[CMD_SET_LEVEL_LENGTH] = {(uint8_t) level};
           write_command_(CMD_SET_LEVEL, command, sizeof(command));
         }
       }
 
       void set_comfort_temperature_(float temperature)
       {
-        if (temperature < 12.0f || temperature > 29.0f)
+        if (temperature < COMFOAIR_MIN_SUPPORTED_TEMP
+         || temperature > COMFOAIR_MAX_SUPPORTED_TEMP)
         {
           ESP_LOGI(TAG, "Ignoring invalid temperature request: %i", temperature);
           return;
@@ -262,680 +346,822 @@ namespace esphome
 
         ESP_LOGI(TAG, "Setting temperature to: %i", temperature);
         {
-          uint8_t command[1] = {(uint8_t)((temperature + 20.0f) * 2.0f)};
+          uint8_t command[CMD_SET_COMFORT_TEMPERATURE_LENGTH] = {(uint8_t) ((temperature + 20.0f) * 2.0f)};
           write_command_(CMD_SET_COMFORT_TEMPERATURE, command, sizeof(command));
         }
       }
 
+      // --- TX functions ---
+      
+      // Build TX-array
       void write_command_(const uint8_t command, const uint8_t *command_data, uint8_t command_data_length)
       {
-        write_byte(COMMAND_PREFIX);
-        write_byte(COMMAND_HEAD);
-        write_byte(0x00);
-
-        uint16_t checksum = 173;
-        checksum += command;
-        checksum += command_data_length;
-
-        write_escaped_byte_(command);
-        write_escaped_byte_(command_data_length);
-
-        for (uint8_t i = 0; i < command_data_length; i++)
+        uint8_t message_au8_au8[MAX_MESSAGE_SIZE];
+        message_au8_au8[0] = 0x00;
+        message_au8_au8[1] = command;
+        message_au8_au8[2] = command_data_length;
+        for (uint8_t idx_u8 = 0; idx_u8 < command_data_length; idx_u8++)
         {
-          uint8_t data_byte = command_data[i];
-          checksum += data_byte;
-          write_escaped_byte_(data_byte);
+          message_au8_au8[3 + idx_u8] = command_data[idx_u8];
         }
+        txMessage_(message_au8_au8);
+      }
 
-        uint8_t checksum_byte = static_cast<uint8_t>(checksum & 0xFF);
-        write_escaped_byte_(checksum_byte);
+      // add prefix, second 0x07, checksum and postfix and transmit that data.
+      void txMessage_(uint8_t message_au8[] /*, tx_serial txPort_en */)
+      {
+        // add 2 bytes "START"
+        // copy "COMMAND" and "SIZE"
+        // copy "DATA" and double each 0x07 in data area
+        // add "CHECKSUM"
+        // add 2 bytes "STOP"
+        // transmit everything to Serial
 
-        write_byte(COMMAND_PREFIX);
-        write_byte(COMMAND_TAIL);
+        ESP_LOGVV(TAG, "TX: cmd: %02X size: %02X - %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X", message_au8[1], message_au8[2], message_au8[3], message_au8[4], message_au8[5], message_au8[6], message_au8[7], message_au8[8], message_au8[9], message_au8[10], message_au8[11], message_au8[12], message_au8[13], message_au8[14], message_au8[15], message_au8[16], message_au8[17], message_au8[18], message_au8[19], message_au8[20], message_au8[21], message_au8[22]);
+
+        uint8_t txBuffer_au8[MAX_MESSAGE_SIZE]; // TX buffer
+        // Start
+        txBuffer_au8[0] = 0x07;
+        txBuffer_au8[1] = 0xF0;
+        // Command
+        txBuffer_au8[2] = message_au8[0];
+        txBuffer_au8[3] = message_au8[1];
+        // Size
+        txBuffer_au8[4] = message_au8[2];
+        // Data
+        uint8_t idx_message_u8 = 3U;
+        uint8_t idx_txBuffer_u8 = 5U;
+        while (idx_message_u8 < message_au8[2] + 3)
+        {
+          // copy current byte
+          txBuffer_au8[idx_txBuffer_u8] = message_au8[idx_message_u8];
+          if (message_au8[idx_message_u8] == 0x07U)
+          {
+            // repeat 0x07 in TX
+            idx_txBuffer_u8++;
+            txBuffer_au8[idx_txBuffer_u8] = 0x07U;
+          }
+          idx_message_u8++;
+          idx_txBuffer_u8++;
+        }
+        // Checksum
+        txBuffer_au8[idx_txBuffer_u8] = calcChecksum_(message_au8);
+        idx_txBuffer_u8++;
+        // Stop
+        txBuffer_au8[idx_txBuffer_u8] = 0x07;
+        idx_txBuffer_u8++;
+        txBuffer_au8[idx_txBuffer_u8] = 0x0F;
+
+        // todo for future use when ComfoAir and ComfoSense are both 
+        // connected to an individual UART on this ESP32:
+        // Either send to CA or CS
+        //
+        // transmit
+        // idx_message_u8 = 0U;
+        // switch (txPort_en)
+        // {
+        // case SERIAL_0_PC:
+        //   while (idx_message_u8 <= idx_txBuffer_u8)
+        //   {
+        //     Serial.write(txBuffer_au8[idx_message_u8]);
+        //     idx_message_u8++;
+        //   }
+        //   break;
+        // case SERIAL_1_ComfoAir:
+        //   while (idx_message_u8 <= idx_txBuffer_u8)
+        //   {
+        //     Serial1.write(txBuffer_au8[idx_message_u8]);
+        //     idx_message_u8++;
+        //   }
+        //   break;
+        // case SERIAL_2_ComfoSense:
+        //   while (idx_message_u8 <= idx_txBuffer_u8)
+        //   {
+        //     Serial2.write(txBuffer_au8[idx_message_u8]);
+        //     idx_message_u8++;
+        //   }
+        //   break;
+        // default:
+        //   break;
+        // }
+        idx_txBuffer_u8++;
+        write_array(txBuffer_au8, idx_txBuffer_u8);
         flush();
       }
 
-      void write_escaped_byte_(uint8_t value)
+      void txACK_(/* tx_serial txPort_en */)
       {
-        write_byte(value);
-        if (value == COMMAND_PREFIX)
-        {
-          write_byte(value);
-        }
+        // send an ACK to Serial
+
+        // todo transmit
+        // switch (txPort_en)
+        // {
+        // case SERIAL_0_PC:
+        //   Serial.write(0x07);
+        //   Serial.write(0xF3);
+        //   break;
+        // case SERIAL_1_ComfoAir:
+        //   Serial1.write(0x07);
+        //   Serial1.write(0xF3);
+        //   break;
+        // case SERIAL_2_ComfoSense:
+        //   Serial2.write(0x07);
+        //   Serial2.write(0xF3);
+        //   break;
+        // default:
+        //   break;
+        // }
+
+        write_byte(COMMAND_PREFIX);
+        write_byte(COMMAND_HEAD_ACK);
+        flush();
       }
 
-      uint8_t comfoair_checksum_(uint8_t command, uint8_t length, const uint8_t *command_data) const
+      // RX & TX common checksum function
+      uint8_t calcChecksum_(uint8_t message_au8[])
       {
-        uint16_t sum = 173;
-        sum += command;
-        sum += length;
-        if (command_data != nullptr)
+        // Calculates checksum.
+        // Doubled 0x07 has to be removed beforehand!
+        uint16_t sum = 0xADU; // = 173
+        uint8_t idx = 0U;
+
+        while (idx <= message_au8[2] + 2)
         {
-          for (uint8_t i = 0; i < length; i++)
-          {
-            sum += command_data[i];
-          }
+          // sum up all message bytes including
+          // "Kommando", "Anzahl Daten" and "Daten"
+          sum = sum + message_au8[idx];
+          idx++;
         }
-        return static_cast<uint8_t>(sum & 0xFF);
+
+        // return only LSB of sum
+        return ((uint8_t)sum);
       }
 
-      optional<bool> check_byte_() const
+      // --- RX functions ---
+      
+      rx_status checkRx_(uint8_t rxBuffer[], uint8_t *index_u8, uint8_t rc)
       {
-        uint8_t index = data_index_;
-        uint8_t byte = data_[index];
+        /* Manage and analyze rx bytes.
+          return indicates ACK or MESSAGE.
+        */
+        rx_status return_val = RX_STATUS_DEFAULT;
 
-        if (index == 0)
+        // store received byte in array
+        rxBuffer[*index_u8] = rc;
+
+        // analyze array
+
+        // Two possible message beginnings:
+        // 1. 0x07 0xF3 -> is an ACK
+        // 2. 0x07 0xF0 -> is the beginning of an actual message which has to end with 0x07 0x0F
+
+        if (*index_u8 == 1U
+          && rxBuffer[0] == 0x07
+          && rxBuffer[1] == 0xF3)
         {
-          return byte == COMMAND_PREFIX;
+          // received ACK
+          return_val = RX_STATUS_RECEIVED_ACK;
+          *index_u8 = 0U;
         }
-
-        if (index == 1)
+        else if (*index_u8 > 1U
+              && rxBuffer[*index_u8 - 2] != 0x07
+              && rxBuffer[*index_u8 - 1] == 0x07
+              && rxBuffer[*index_u8] == 0xF3)
         {
-          if (byte == COMMAND_ACK)
+          // received ACK
+          return_val = RX_STATUS_RECEIVED_ACK;
+          *index_u8 = 0U;
+        }
+        else if (*index_u8 > 1U
+              && rxBuffer[*index_u8 - 2] != 0x07
+              && rxBuffer[*index_u8 - 1] == 0x07
+              && rxBuffer[*index_u8] == 0xF0)
+        {
+          // This has to be the start of a new message.
+          //
+          // This assumption is true as long as there is no Kommando 0x.. 0x07
+          // followed by a size of 0xF0. But afaik the Kommando 0x00 0x07 is of
+          // size 3 and other 0x.. 0x07 commands are unknown.
+          rxBuffer[0] = 0x07;
+          rxBuffer[1] = 0xF0;
+          *index_u8 = 2U;
+          return_val = RX_STATUS_RECEIVED_START_OF_MESSAGE;
+        }
+        else if (rxBuffer[0] == 0x07
+              && rxBuffer[1] == 0xF0
+              && rxBuffer[*index_u8 - 1] == 0x07
+              && rxBuffer[*index_u8] == 0x0F)
+        {
+          // new message received:
+          // remove "START" and "STOP" plus
+          // eliminate double 0x07 within data area
+          *index_u8 = isolateRxMessage_(rxBuffer, *index_u8);
+
+          // test checksum
+          if (calcChecksum_(rxBuffer) == rxBuffer[*index_u8])
           {
-            return {};
+            // message is valid
+            return_val = RX_STATUS_RECEIVED_MESSAGE;
+            *index_u8 = 0U;
           }
           else
           {
-            return byte == COMMAND_HEAD;
+            // message invalid
+            return_val = RX_STATUS_RECEIVED_INVALID_MESSAGE;
+            ESP_LOGD(TAG, "RX: Invalid checksum (from CA350): %02X(c) != %02X(rx) (cmd: %02X size: %02X - %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X)", calcChecksum_(rxBuffer), rxBuffer[*index_u8], rxBuffer[1], rxBuffer[2], rxBuffer[3], rxBuffer[4], rxBuffer[5], rxBuffer[6], rxBuffer[7], rxBuffer[8], rxBuffer[9], rxBuffer[10], rxBuffer[11], rxBuffer[12], rxBuffer[13], rxBuffer[14], rxBuffer[15], rxBuffer[16], rxBuffer[17], rxBuffer[18], rxBuffer[19], rxBuffer[20], rxBuffer[21], rxBuffer[22]);
+            *index_u8 = 0U;
           }
         }
-
-        if (index == 2)
+        else
         {
-          return byte == 0x00;
+          return_val = RX_STATUS_WRAPPED_BUFFER_INDEX;
+          *index_u8 = (1 + *index_u8) % MAX_MESSAGE_SIZE;
         }
-
-        if (index < COMMAND_LEN_HEAD)
-        {
-          return true;
-        }
-
-        uint8_t data_length = data_[COMMAND_IDX_DATA];
-
-        if ((COMMAND_LEN_HEAD + data_length + COMMAND_LEN_TAIL) > sizeof(data_))
-        {
-          ESP_LOGW(TAG, "ComfoAir message too large");
-          return false;
-        }
-
-        if (index < COMMAND_LEN_HEAD + data_length)
-        {
-          return true;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length)
-        {
-          // checksum is without checksum bytes
-          uint8_t checksum = comfoair_checksum_(
-              data_[COMMAND_IDX_MSG_ID], data_length, data_ + COMMAND_LEN_HEAD);
-          if (checksum != byte)
-          {
-            // ESP_LOGW(TAG, "%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X", data_[0], data_[1], data_[2], data_[3], data_[4], data_[5], data_[6], data_[7], data_[8], data_[9], data_[10]);
-            ESP_LOGW(TAG, "ComfoAir Checksum doesn't match: 0x%02X!=0x%02X", byte, checksum);
-            return false;
-          }
-          return true;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length + 1)
-        {
-          return byte == COMMAND_PREFIX;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length + 2)
-        {
-          if (byte != COMMAND_TAIL)
-          {
-            return false;
-          }
-        }
-
-        return {};
+        return(return_val);
       }
 
-      void parse_data_()
+      uint8_t isolateRxMessage_(uint8_t rxBuffer[], uint8_t size)
+      {
+        // remove "START" (2 bytes)
+        // copy "COMMAND" and "SIZE" (3 bytes)
+        // copy "DATA" while removing doubled 0x07 in data area if applicable
+        // copy "Checksum"
+        // remove/ignore "STOP" (2 bytes)
+        // return resulting size of array
+        uint8_t read_idx_u8 = 2U; // skip/remove/ignore "START"-bytes
+        uint8_t write_idx_u8 = 0U;
+
+        // copy "COMAND" and "SIZE"
+        while (read_idx_u8 < 5U)
+        {
+          rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+          read_idx_u8++;
+          write_idx_u8++;
+        }
+
+        // copy "DATA" while removing doubled 0x07 in data area if applicable
+        while (((write_idx_u8 - 3U) < rxBuffer[2]) && (read_idx_u8 < size - 2))
+        {
+          rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+          if ((rxBuffer[read_idx_u8] == 0x07U) && (rxBuffer[read_idx_u8 + 1U] == 0x07U))
+          {
+            // skip next byte which is expected to be 0x07 according to reverse
+            // engineered protocol
+            read_idx_u8++;
+          }
+          read_idx_u8++;
+          write_idx_u8++;
+        }
+
+        // copy "Checksum"
+        rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+        // return resulting size of array
+        return (write_idx_u8);
+      }
+
+      void parseRxMessage_(uint8_t *message_au8)
       {
         status_clear_warning();
-        uint8_t *msg = &data_[COMMAND_LEN_HEAD];
+        // message_au8[0] = 0x00
+        // message_au8[1] = command byte
+        // message_au8[2] = data_length
+        // message_au8[3] = first byte of data
 
-        switch (data_[COMMAND_IDX_MSG_ID])
-        {
-        case RES_GET_BOOTLOADER_VERSION:
-          memcpy(bootloader_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_FIRMWARE_VERSION:
-          memcpy(firmware_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_CONNECTOR_BOARD_VERSION:
-          memcpy(connector_board_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_FAN_STATUS:
-        {
-          if (intake_fan_speed != nullptr)
-          {
-            intake_fan_speed->publish_state(msg[0]);
-          }
-          if (exhaust_fan_speed != nullptr)
-          {
-            exhaust_fan_speed->publish_state(msg[1]);
-          }
-          if (intake_fan_speed_rpm != nullptr)
-          {
-            intake_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / get_uint16_(2)));
-          }
-          if (exhaust_fan_speed_rpm != nullptr)
-          {
-            exhaust_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / get_uint16_(4)));
-          }
-          break;
-        }
-        case RES_GET_VALVE_STATUS:
-        {
-          if (bypass_valve != nullptr)
-          {
-            bypass_valve->publish_state(msg[0]);
-          }
-          if (bypass_valve_open != nullptr)
-          {
-            bypass_valve_open->publish_state(msg[0] != 0);
-          }
-          if (preheating_state != nullptr)
-          {
-            preheating_state->publish_state(msg[1] != 0);
-          }
-          if (motor_current_bypass != nullptr)
-          {
-            motor_current_bypass->publish_state(msg[2]);
-          }
-          if (motor_current_preheating != nullptr)
-          {
-            motor_current_preheating->publish_state(msg[3]);
-          }
-          break;
-        }
-        case RES_GET_BYPASS_CONTROL_STATUS:
-        {
-          if (bypass_factor != nullptr)
-          {
-            bypass_factor->publish_state(msg[2]);
-          }
-          if (bypass_step != nullptr)
-          {
-            bypass_step->publish_state(msg[3]);
-          }
-          if (bypass_correction != nullptr)
-          {
-            bypass_correction->publish_state(msg[4]);
-          }
-          if (summer_mode != nullptr)
-          {
-            summer_mode->publish_state(msg[6] != 0);
-          }
-          break;
-        }
-        case RES_GET_TEMPERATURE_STATUS:
-        {
+        uint8_t msg_command_u8 = message_au8[COMMAND_IDX_MSG_ID - 2]; // -2 because prefix is removed from data
+        uint8_t msg_length_u8  = message_au8[COMMAND_IDX_PROTOCOL_LENGTH - 2];
+        uint8_t *msg_data      = &message_au8[COMMAND_IDX_PROTOCOL_DATA_AREA - 2];
 
-          // T1 / outside air
-          if (outside_air_temperature != nullptr)
-          {
-            outside_air_temperature->publish_state((float)msg[0] / 2.0f - 20.0f);
-          }
-          // T2 / supply air
-          if (supply_air_temperature != nullptr)
-          {
-            supply_air_temperature->publish_state((float)msg[1] / 2.0f - 20.0f);
-          }
-          // T3 / return air
-          if (return_air_temperature != nullptr)
-          {
-            return_air_temperature->publish_state((float)msg[2] / 2.0f - 20.0f);
-          }
-          // T4 / exhaust air
-          if (exhaust_air_temperature != nullptr)
-          {
-            exhaust_air_temperature->publish_state((float)msg[3] / 2.0f - 20.0f);
-          }
-          break;
-        }
-        case RES_GET_SENSOR_DATA:
-        {
-
-          if (enthalpy_temperature != nullptr)
-          {
-            enthalpy_temperature->publish_state((float)msg[0] / 2.0f - 20.0f);
-          }
-
-          break;
-        }
-        case RES_GET_VENTILATION_LEVEL:
-        {
-
-          ESP_LOGD(TAG, "Level %02x", msg[8]);
-
-          if (return_air_level != nullptr)
-          {
-            return_air_level->publish_state(msg[6]);
-          }
-          if (supply_air_level != nullptr)
-          {
-            supply_air_level->publish_state(msg[7]);
-          }
-
-          if (ventilation_level != nullptr)
-          {
-            ventilation_level->publish_state(msg[8] - 1);
-          }
-
-          // Fan Speed
-          switch (msg[8])
-          {
-          case 0x00:
-            fan_mode.reset();
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
+        switch (msg_command_u8) {
+          case RES_GET_BOOTLOADER_VERSION:
+            memcpy(bootloader_version_, msg_data, msg_length_u8);
             break;
-          case 0x01:
-            fan_mode = climate::CLIMATE_FAN_OFF;
-            mode = climate::CLIMATE_MODE_OFF;
+          case RES_GET_FIRMWARE_VERSION:
+            memcpy(firmware_version_, msg_data, msg_length_u8);
             break;
-          case 0x02:
-            fan_mode = climate::CLIMATE_FAN_LOW;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
+          case RES_GET_CONNECTOR_BOARD_VERSION:
+            memcpy(connector_board_version_, msg_data, msg_length_u8);
             break;
-          case 0x03:
-            fan_mode = climate::CLIMATE_FAN_MEDIUM;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          case 0x04:
-            fan_mode = climate::CLIMATE_FAN_HIGH;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          }
-
-          publish_state();
-
-          // Supply air fan active (1 = active / 0 = inactive)
-          if (supply_fan_active != nullptr)
+          case RES_GET_FAN_STATUS:
           {
-            supply_fan_active->publish_state(msg[9] == 1);
-          }
-          break;
-        }
-        case RES_GET_FAULTS:
-        {
-          if (filter_status != nullptr)
-          {
-            uint8_t status = msg[8];
-            filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
-          }
-          break;
-        }
-        case RES_GET_TEMPERATURES:
-        {
-
-          // comfort temperature
-          target_temperature = (float)msg[0] / 2.0f - 20.0f;
-          publish_state();
-
-          // T1 / outside air
-          if (outside_air_temperature != nullptr && msg[5] & 0x01)
-          {
-            outside_air_temperature->publish_state((float)msg[1] / 2.0f - 20.0f);
-          }
-          // T2 / supply air
-          if (supply_air_temperature != nullptr && msg[5] & 0x02)
-          {
-            supply_air_temperature->publish_state((float)msg[2] / 2.0f - 20.0f);
-          }
-          // T3 / exhaust air
-          if (return_air_temperature != nullptr && msg[5] & 0x04)
-          {
-            return_air_temperature->publish_state((float)msg[3] / 2.0f - 20.0f);
-            current_temperature = (float)msg[3] / 2.0f - 20.0f;
-          }
-          // T4 / continued air
-          if (exhaust_air_temperature != nullptr && msg[5] & 0x08)
-          {
-            exhaust_air_temperature->publish_state((float)msg[4] / 2.0f - 20.0f);
-          }
-          // EWT
-          if (ewt_temperature != nullptr && msg[5] & 0x10)
-          {
-            ewt_temperature->publish_state((float)msg[6] / 2.0f - 20.0f);
-          }
-          // reheating
-          if (reheating_temperature != nullptr && msg[5] & 0x20)
-          {
-            reheating_temperature->publish_state((float)msg[7] / 2.0f - 20.0f);
-          }
-          // kitchen hood
-          if (kitchen_hood_temperature != nullptr && msg[5] & 0x40)
-          {
-            kitchen_hood_temperature->publish_state((float)msg[8] / 2.0f - 20.0f);
-          }
-
-          break;
-        }
-        case RES_GET_STATUS:
-        {
-          if (preheating_present != nullptr)
-          {
-            preheating_present->publish_state(msg[0]);
-          }
-
-          if (bypass_present != nullptr)
-          {
-            bypass_present->publish_state(msg[1]);
-          }
-
-          if (type != nullptr)
-          {
-            type->publish_state(msg[2] == 1 ? "Left" : (msg[2] == 2 ? "Right" : "Unknown"));
-          }
-
-          publish_size_entities_(msg[3]);
-
-          if (options_present != nullptr)
-          {
-            options_present->publish_state(msg[4]);
-          }
-
-          if (fireplace_present != nullptr)
-          {
-            fireplace_present->publish_state(msg[4] & 0x01);
-          }
-
-          if (kitchen_hood_present != nullptr)
-          {
-            kitchen_hood_present->publish_state(msg[4] & 0x02);
-          }
-
-          if (postheating_present != nullptr)
-          {
-            postheating_present->publish_state(msg[4] & 0x04);
-          }
-
-          if (postheating_pwm_mode_present != nullptr)
-          {
-            postheating_pwm_mode_present->publish_state(msg[4] & 0x40);
-          }
-
-          if (p10_active != nullptr)
-          {
-            p10_active->publish_state(msg[6] & 0x01);
-          }
-
-          if (p11_active != nullptr)
-          {
-            p11_active->publish_state(msg[6] & 0x02);
-          }
-
-          if (p12_active != nullptr)
-          {
-            p12_active->publish_state(msg[6] & 0x04);
-          }
-
-          if (p13_active != nullptr)
-          {
-            p13_active->publish_state(msg[6] & 0x08);
-          }
-
-          if (p14_active != nullptr)
-          {
-            p14_active->publish_state(msg[6] & 0x10);
-          }
-
-          if (p15_active != nullptr)
-          {
-            p15_active->publish_state(msg[6] & 0x20);
-          }
-
-          if (p16_active != nullptr)
-          {
-            p16_active->publish_state(msg[6] & 0x40);
-          }
-
-          if (p17_active != nullptr)
-          {
-            p17_active->publish_state(msg[6] & 0x80);
-          }
-
-          if (p18_active != nullptr)
-          {
-            p18_active->publish_state(msg[7] & 0x01);
-          }
-
-          if (p19_active != nullptr)
-          {
-            p19_active->publish_state(msg[7] & 0x02);
-          }
-
-          if (p90_active != nullptr)
-          {
-            p90_active->publish_state(msg[8] & 0x01);
-          }
-
-          if (p91_active != nullptr)
-          {
-            p91_active->publish_state(msg[8] & 0x02);
-          }
-
-          if (p92_active != nullptr)
-          {
-            p92_active->publish_state(msg[8] & 0x04);
-          }
-
-          if (p93_active != nullptr)
-          {
-            p93_active->publish_state(msg[8] & 0x08);
-          }
-
-          if (p94_active != nullptr)
-          {
-            p94_active->publish_state(msg[8] & 0x10);
-          }
-
-          if (p95_active != nullptr)
-          {
-            p95_active->publish_state(msg[8] & 0x20);
-          }
-
-          if (p96_active != nullptr)
-          {
-            p96_active->publish_state(msg[8] & 0x40);
-          }
-
-          if (p97_active != nullptr)
-          {
-            p97_active->publish_state(msg[8] & 0x80);
-          }
-
-          if (enthalpy_present != nullptr)
-          {
-            enthalpy_present->publish_state(msg[9]);
-          }
-
-          if (ewt_present != nullptr)
-          {
-            ewt_present->publish_state(msg[10]);
-          }
-
-          if (data_[COMMAND_IDX_DATA] >= 11)
-          {
-            status_payload_[0] = msg[0];
-            status_payload_[1] = msg[1];
-            status_payload_[2] = msg[2];
-            status_payload_[3] = msg[3];
-            status_payload_[4] = msg[4];
-            status_payload_[5] = msg[5];
-            status_payload_[6] = msg[9];
-            status_payload_[7] = msg[10];
-            status_payload_valid_ = true;
-          }
-          else
-          {
-            status_payload_valid_ = false;
-          }
-          break;
-        }
-        case RES_GET_OPERATION_HOURS:
-        {
-          if (level0_hours != nullptr)
-          {
-            level0_hours->publish_state((msg[0] << 16) | (msg[1] << 8) | msg[2]);
-          }
-
-          if (level1_hours != nullptr)
-          {
-            level1_hours->publish_state((msg[3] << 16) | (msg[4] << 8) | msg[5]);
-          }
-
-          if (level2_hours != nullptr)
-          {
-            level2_hours->publish_state((msg[6] << 16) | (msg[7] << 8) | msg[8]);
-          }
-
-          if (level3_hours != nullptr)
-          {
-            level3_hours->publish_state((msg[17] << 16) | (msg[18] << 8) | msg[19]);
-          }
-
-          if (frost_protection_hours != nullptr)
-          {
-            frost_protection_hours->publish_state((msg[9] << 8) | msg[10]);
-          }
-
-          if (bypass_open_hours != nullptr)
-          {
-            bypass_open_hours->publish_state((msg[13] << 8) | msg[14]);
-          }
-
-          if (preheating_hours != nullptr)
-          {
-            preheating_hours->publish_state((msg[11] << 8) | msg[12]);
-          }
-
-          if (filter_hours != nullptr)
-          {
-            filter_hours->publish_state((msg[15] << 8) | msg[16]);
-          }
-          break;
-        }
-
-        case RES_GET_PREHEATING_STATUS:
-        {
-          if (preheating_valve != nullptr)
-          {
-            std::string name_preheating_valve;
-            switch (msg[0])
+            if (intake_fan_speed != nullptr)
             {
-            case 0:
-              name_preheating_valve = "Closed";
-              break;
-
-            case 1:
-              name_preheating_valve = "Open";
-              break;
-
-            default:
-              name_preheating_valve = "Unknown";
-              break;
+              intake_fan_speed->publish_state(msg_data[0]);
             }
-            preheating_valve->publish_state(name_preheating_valve);
-          }
-
-          if (frost_protection_active != nullptr)
-          {
-            frost_protection_active->publish_state(msg[1] != 0);
-          }
-
-          if (preheating_state != nullptr)
-          {
-            preheating_state->publish_state(msg[2] != 0);
-          }
-
-          if (frost_protection_minutes != nullptr)
-          {
-            frost_protection_minutes->publish_state((msg[3] << 8) | msg[4]);
-          }
-
-          if (frost_protection_level != nullptr)
-          {
-            std::string name_frost_protection_level;
-            switch (msg[5])
+            if (exhaust_fan_speed != nullptr)
             {
-            case 0:
-              name_frost_protection_level = "GuaranteedProtection";
-              break;
-
-            case 1:
-              name_frost_protection_level = "HighProtection";
-              break;
-
-            case 2:
-              name_frost_protection_level = "NominalProtection";
-              break;
-
-            case 3:
-              name_frost_protection_level = "Economy";
-              break;
-
-            default:
-              name_frost_protection_level = "Unknown";
-              break;
+              exhaust_fan_speed->publish_state(msg_data[1]);
             }
-            frost_protection_level->publish_state(name_frost_protection_level);
+            if (intake_fan_speed_rpm != nullptr)
+            {
+              intake_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / (uint16_t)(msg_data[2] << 8 | msg_data[3]))); // get_uint16_(2));
+            }
+            if (exhaust_fan_speed_rpm != nullptr)
+            {
+              exhaust_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / (uint16_t)(msg_data[4] << 8 | msg_data[5]))); // get_uint16_(4));
+            }
+            break;
           }
-          break;
-        }
-        case RES_GET_TIME_DELAY:
-        {
-          if (bathroom_switch_on_delay_minutes != nullptr)
+          case RES_GET_VALVE_STATUS:
           {
-            bathroom_switch_on_delay_minutes->publish_state(msg[0]);
+            if (bypass_valve != nullptr)
+            {
+              bypass_valve->publish_state(msg_data[0]);
+            }
+            if (bypass_valve_open != nullptr)
+            {
+              bypass_valve_open->publish_state(msg_data[0] != 0);
+            }
+            if (preheating_state != nullptr)
+            {
+              preheating_state->publish_state(msg_data[1] != 0);
+            }
+            if (motor_current_bypass != nullptr)
+            {
+              motor_current_bypass->publish_state(msg_data[2]);
+            }
+            if (motor_current_preheating != nullptr)
+            {
+              motor_current_preheating->publish_state(msg_data[3]);
+            }
+            break;
           }
-
-          if (bathroom_switch_off_delay_minutes != nullptr)
+          case RES_GET_BYPASS_CONTROL_STATUS:
           {
-            bathroom_switch_off_delay_minutes->publish_state(msg[1]);
+            if (bypass_factor != nullptr)
+            {
+              bypass_factor->publish_state(msg_data[2]);
+            }
+            if (bypass_step != nullptr)
+            {
+              bypass_step->publish_state(msg_data[3]);
+            }
+            if (bypass_correction != nullptr)
+            {
+              bypass_correction->publish_state(msg_data[4]);
+            }
+            if (summer_mode != nullptr)
+            {
+              summer_mode->publish_state(msg_data[6] != 0);
+            }
+            break;
           }
-
-          if (l1_switch_off_delay_minutes != nullptr)
+          case RES_GET_TEMPERATURE_STATUS:
           {
-            l1_switch_off_delay_minutes->publish_state(msg[2]);
+            // T1 / outside air
+            if (outside_air_temperature != nullptr)
+            {
+              outside_air_temperature->publish_state((float) msg_data[0] / 2.0f - 20.0f);
+            }
+            // T2 / supply air
+            if (supply_air_temperature != nullptr)
+            {
+              supply_air_temperature->publish_state((float) msg_data[1] / 2.0f - 20.0f);
+            }
+            // T3 / return air
+            if (return_air_temperature != nullptr)
+            {
+              return_air_temperature->publish_state((float) msg_data[2] / 2.0f - 20.0f);
+            }
+            // T4 / exhaust air
+            if (exhaust_air_temperature != nullptr)
+            {
+              exhaust_air_temperature->publish_state((float) msg_data[3] / 2.0f - 20.0f);
+            }
+            break;
           }
-
-          if (boost_ventilation_minutes != nullptr)
+          case RES_GET_SENSOR_DATA:
           {
-            boost_ventilation_minutes->publish_state(msg[3]);
+            if (enthalpy_temperature != nullptr)
+            {
+              enthalpy_temperature->publish_state((float) msg_data[0] / 2.0f - 20.0f);
+            }
+            break;
           }
-
-          if (filter_warning_weeks != nullptr)
+          case RES_GET_VENTILATION_LEVEL:
           {
-            filter_warning_weeks->publish_state(msg[4]);
-          }
+            ESP_LOGD(TAG, "Level %02X", msg_data[8]);
+            ESP_LOGV(TAG, "Off ab %i - Off zu %i - Low ab %i - Low zu %i - Middle ab %i - Middle zu %i - High ab %i - High zu %i", msg_data[0], msg_data[3], msg_data[1], msg_data[4], msg_data[2], msg_data[5], msg_data[10], msg_data[11]);
 
-          if (rf_high_time_short_minutes != nullptr)
+            if (return_air_level != nullptr)
+            {
+              return_air_level->publish_state(msg_data[6]);
+            }
+            if (supply_air_level != nullptr)
+            {
+              supply_air_level->publish_state(msg_data[7]);
+            }
+
+            if (ventilation_level != nullptr)
+            {
+              ventilation_level->publish_state(msg_data[8] - 1);
+            }
+
+            // Fan Speed
+            switch(msg_data[8])
+            {
+              case 0x00:
+                fan_mode.reset();
+                mode = climate::CLIMATE_MODE_FAN_ONLY;
+                break;
+              case 0x01:
+                fan_mode = climate::CLIMATE_FAN_OFF;
+                mode = climate::CLIMATE_MODE_OFF;
+                break;
+              case 0x02:
+                fan_mode = climate::CLIMATE_FAN_LOW;
+                mode = climate::CLIMATE_MODE_FAN_ONLY;
+                break;
+              case 0x03:
+                fan_mode = climate::CLIMATE_FAN_MEDIUM;
+                mode = climate::CLIMATE_MODE_FAN_ONLY;
+              break;
+              case 0x04:
+                fan_mode = climate::CLIMATE_FAN_HIGH;
+                mode = climate::CLIMATE_MODE_FAN_ONLY;
+                break;
+            }
+
+            publish_state();
+
+            // Supply air fan active (1 = active / 0 = inactive)
+            if (supply_fan_active != nullptr)
+            {
+              supply_fan_active->publish_state(msg_data[9] == 1);
+            }
+            break;
+          }
+          case RES_GET_FAULTS:
           {
-            rf_high_time_short_minutes->publish_state(msg[5]);
+            if (filter_status != nullptr)
+            {
+              uint8_t status = msg_data[8];
+              filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
+            }
+            break;
           }
-
-          if (rf_high_time_long_minutes != nullptr)
+          case RES_GET_TEMPERATURES:
           {
-            rf_high_time_long_minutes->publish_state(msg[6]);
-          }
+            // comfort temperature
+            target_temperature = (float) msg_data[0] / 2.0f - 20.0f;
+            publish_state();
 
-          if (extractor_hood_switch_off_delay_minutes != nullptr)
+            // T1 / outside air
+            if (outside_air_temperature != nullptr && msg_data[5] & 0x01)
+            {
+              outside_air_temperature->publish_state((float) msg_data[1] / 2.0f - 20.0f);
+            }
+            // T2 / supply air
+            if (supply_air_temperature != nullptr && msg_data[5] & 0x02)
+            {
+              supply_air_temperature->publish_state((float) msg_data[2] / 2.0f - 20.0f);
+            }
+            // T3 / exhaust air
+            if (return_air_temperature != nullptr && msg_data[5] & 0x04)
+            {
+              return_air_temperature->publish_state((float) msg_data[3] / 2.0f - 20.0f);
+              current_temperature = (float) msg_data[3] / 2.0f - 20.0f;
+            }
+            // T4 / continued air
+            if (exhaust_air_temperature != nullptr && msg_data[5] & 0x08)
+            {
+              exhaust_air_temperature->publish_state((float) msg_data[4] / 2.0f - 20.0f);
+            }
+            // EWT
+            if (ewt_temperature != nullptr && msg_data[5] & 0x10)
+            {
+              ewt_temperature->publish_state((float) msg_data[6] / 2.0f - 20.0f);
+            }
+            // reheating
+            if (reheating_temperature != nullptr && msg_data[5] & 0x20)
+            {
+              reheating_temperature->publish_state((float) msg_data[7] / 2.0f - 20.0f);
+            }
+            // kitchen hood
+            if (kitchen_hood_temperature != nullptr && msg_data[5] & 0x40)
+            {
+              kitchen_hood_temperature->publish_state((float) msg_data[8] / 2.0f - 20.0f);
+            }
+            break;
+          }
+          case RES_GET_STATUS:
           {
-            extractor_hood_switch_off_delay_minutes->publish_state(msg[7]);
-          }
+            if (preheating_present != nullptr)
+            {
+              preheating_present->publish_state(msg_data[0]);
+            }
 
-          break;
-        }
+            if (bypass_present != nullptr)
+            {
+              bypass_present->publish_state(msg_data[1]);
+            }
+
+            if (type != nullptr)
+            {
+              type->publish_state(msg_data[2] == 1 ? "Left" : (msg_data[2] == 2 ? "Right" : "Unknown"));
+            }
+
+            publish_size_entities_(msg_data[3]);
+
+            if (options_present != nullptr)
+            {
+              options_present->publish_state(msg_data[4]);
+            }
+
+            if (fireplace_present != nullptr)
+            {
+              fireplace_present->publish_state(msg_data[4] & 0x01);
+            }
+
+            if (kitchen_hood_present != nullptr)
+            {
+              kitchen_hood_present->publish_state(msg_data[4] & 0x02);
+            }
+
+            if (postheating_present != nullptr)
+            {
+              postheating_present->publish_state(msg_data[4] & 0x04);
+            }
+
+            if (postheating_pwm_mode_present != nullptr)
+            {
+              postheating_pwm_mode_present->publish_state(msg_data[4] & 0x40);
+            }
+
+            if (p10_active != nullptr)
+            {
+              p10_active->publish_state(msg_data[6] & 0x01);
+            }
+
+            if (p11_active != nullptr)
+            {
+              p11_active->publish_state(msg_data[6] & 0x02);
+            }
+
+            if (p12_active != nullptr)
+            {
+              p12_active->publish_state(msg_data[6] & 0x04);
+            }
+
+            if (p13_active != nullptr)
+            {
+              p13_active->publish_state(msg_data[6] & 0x08);
+            }
+
+            if (p14_active != nullptr)
+            {
+              p14_active->publish_state(msg_data[6] & 0x10);
+            }
+
+            if (p15_active != nullptr)
+            {
+              p15_active->publish_state(msg_data[6] & 0x20);
+            }
+
+            if (p16_active != nullptr)
+            {
+              p16_active->publish_state(msg_data[6] & 0x40);
+            }
+
+            if (p17_active != nullptr)
+            {
+              p17_active->publish_state(msg_data[6] & 0x80);
+            }
+
+            if (p18_active != nullptr)
+            {
+              p18_active->publish_state(msg_data[7] & 0x01);
+            }
+
+            if (p19_active != nullptr)
+            {
+              p19_active->publish_state(msg_data[7] & 0x02);
+            }
+
+            if (p90_active != nullptr)
+            {
+              p90_active->publish_state(msg_data[8] & 0x01);
+            }
+
+            if (p91_active != nullptr)
+            {
+              p91_active->publish_state(msg_data[8] & 0x02);
+            }
+
+            if (p92_active != nullptr)
+            {
+              p92_active->publish_state(msg_data[8] & 0x04);
+            }
+
+            if (p93_active != nullptr)
+            {
+              p93_active->publish_state(msg_data[8] & 0x08);
+            }
+
+            if (p94_active != nullptr)
+            {
+              p94_active->publish_state(msg_data[8] & 0x10);
+            }
+
+            if (p95_active != nullptr)
+            {
+              p95_active->publish_state(msg_data[8] & 0x20);
+            }
+
+            if (p96_active != nullptr)
+            {
+              p96_active->publish_state(msg_data[8] & 0x40);
+            }
+
+            if (p97_active != nullptr)
+            {
+              p97_active->publish_state(msg_data[8] & 0x80);
+            }
+
+            if (enthalpy_present != nullptr)
+            {
+              enthalpy_present->publish_state(msg_data[9]);
+            }
+
+            if (ewt_present != nullptr)
+            {
+              ewt_present->publish_state(msg_data[10]);
+            }
+
+            if (msg_length_u8 >= 11)
+            {
+              status_payload_[0] = msg_data[0];
+              status_payload_[1] = msg_data[1];
+              status_payload_[2] = msg_data[2];
+              status_payload_[3] = msg_data[3];
+              status_payload_[4] = msg_data[4];
+              status_payload_[5] = msg_data[5];
+              status_payload_[6] = msg_data[9];
+              status_payload_[7] = msg_data[10];
+              status_payload_valid_ = true;
+            }
+            else
+            {
+              status_payload_valid_ = false;
+            }
+            break;
+          }
+          case RES_GET_OPERATION_HOURS:
+          {
+            if (level0_hours != nullptr)
+            {
+              level0_hours->publish_state((msg_data[0] << 16) | (msg_data[1] << 8) | msg_data[2]);
+            }
+
+            if (level1_hours != nullptr)
+            {
+              level1_hours->publish_state((msg_data[3] << 16) | (msg_data[4] << 8) | msg_data[5]);
+            }
+
+            if (level2_hours != nullptr)
+            {
+              level2_hours->publish_state((msg_data[6] << 16) | (msg_data[7] << 8) | msg_data[8]);
+            }
+
+            if (level3_hours != nullptr)
+            {
+              level3_hours->publish_state((msg_data[17] << 16) | (msg_data[18] << 8) | msg_data[19]);
+            }
+
+            if (frost_protection_hours != nullptr)
+            {
+              frost_protection_hours->publish_state((msg_data[9] << 8) | msg_data[10]);
+            }
+
+            if (bypass_open_hours != nullptr)
+            {
+              bypass_open_hours->publish_state((msg_data[13] << 8) | msg_data[14]);
+            }
+
+            if (preheating_hours != nullptr)
+            {
+              preheating_hours->publish_state((msg_data[11] << 8) | msg_data[12]);
+            }
+
+            if (filter_hours != nullptr)
+            {
+              filter_hours->publish_state((msg_data[15] << 8) | msg_data[16]);
+            }
+            break;
+          }
+          case RES_GET_PREHEATING_STATUS:
+          {
+            if (preheating_valve != nullptr)
+            {
+              std::string name_preheating_valve;
+              switch (msg_data[0])
+              {
+              case 0:
+                name_preheating_valve = "Closed";
+                break;
+
+              case 1:
+                name_preheating_valve = "Open";
+                break;
+
+              default:
+                name_preheating_valve = "Unknown";
+                break;
+              }
+              preheating_valve->publish_state(name_preheating_valve);
+            }
+
+            if (frost_protection_active != nullptr)
+            {
+              frost_protection_active->publish_state(msg_data[1] != 0);
+            }
+
+            if (preheating_state != nullptr)
+            {
+              preheating_state->publish_state(msg_data[2] != 0);
+            }
+
+            if (frost_protection_minutes != nullptr)
+            {
+              frost_protection_minutes->publish_state((msg_data[3] << 8) | msg_data[4]);
+            }
+
+            if (frost_protection_level != nullptr)
+            {
+              std::string name_frost_protection_level;
+              switch (msg_data[5])
+              {
+              case 0:
+                name_frost_protection_level = "GuaranteedProtection";
+                break;
+
+              case 1:
+                name_frost_protection_level = "HighProtection";
+                break;
+
+              case 2:
+                name_frost_protection_level = "NominalProtection";
+                break;
+
+              case 3:
+                name_frost_protection_level = "Economy";
+                break;
+
+              default:
+                name_frost_protection_level = "Unknown";
+                break;
+              }
+              frost_protection_level->publish_state(name_frost_protection_level);
+            }
+            break;
+          }
+          case RES_GET_TIME_DELAY:
+          {
+            if (bathroom_switch_on_delay_minutes != nullptr)
+            {
+              bathroom_switch_on_delay_minutes->publish_state(msg_data[0]);
+            }
+
+            if (bathroom_switch_off_delay_minutes != nullptr)
+            {
+              bathroom_switch_off_delay_minutes->publish_state(msg_data[1]);
+            }
+
+            if (l1_switch_off_delay_minutes != nullptr)
+            {
+              l1_switch_off_delay_minutes->publish_state(msg_data[2]);
+            }
+
+            if (boost_ventilation_minutes != nullptr)
+            {
+              boost_ventilation_minutes->publish_state(msg_data[3]);
+            }
+
+            if (filter_warning_weeks != nullptr)
+            {
+              filter_warning_weeks->publish_state(msg_data[4]);
+            }
+
+            if (rf_high_time_short_minutes != nullptr)
+            {
+              rf_high_time_short_minutes->publish_state(msg_data[5]);
+            }
+
+            if (rf_high_time_long_minutes != nullptr)
+            {
+              rf_high_time_long_minutes->publish_state(msg_data[6]);
+            }
+
+            if (extractor_hood_switch_off_delay_minutes != nullptr)
+            {
+              extractor_hood_switch_off_delay_minutes->publish_state(msg_data[7]);
+            }
+            break;
+          }
         }
       }
 
+      // --- getter ---
+      
       void get_fan_status_()
       {
         if (intake_fan_speed != nullptr ||
@@ -1031,24 +1257,13 @@ namespace esphome
         write_command_(CMD_GET_TIME_DELAY, nullptr, 0);
       }
 
-      uint8_t get_uint8_t_(uint8_t start_index) const
-      {
-        return data_[COMMAND_LEN_HEAD + start_index];
-      }
-
-      uint16_t get_uint16_(uint8_t start_index) const
-      {
-        return (uint16_t(data_[COMMAND_LEN_HEAD + start_index + 1] | data_[COMMAND_LEN_HEAD + start_index] << 8));
-      }
-
       void publish_size_entities_(uint8_t raw_size);
       const char *unit_size_text_label_(uint8_t raw_size) const;
       const char *unit_size_option_label_(uint8_t raw_size) const;
 
-      uint8_t data_[30];
-      uint8_t data_index_{0};
-      int8_t update_counter_{-4};
-      const int8_t num_update_counter_elements_{9};
+      uint8_t caRxBuffer_au8[MAX_MESSAGE_SIZE];
+      uint8_t caRxIdx_u8 = 0;
+      int8_t update_counter_{-10};
       uint8_t status_payload_[8]{0};
       bool status_payload_valid_{false};
       uint8_t current_unit_size_{0};
@@ -1135,6 +1350,8 @@ namespace esphome
       sensor::Sensor *rf_high_time_short_minutes{nullptr};
       sensor::Sensor *rf_high_time_long_minutes{nullptr};
       sensor::Sensor *extractor_hood_switch_off_delay_minutes{nullptr};
+
+      // public functions
 
       void set_type(text_sensor::TextSensor *type) { this->type = type; };
       void set_size(text_sensor::TextSensor *size) { this->size = size; };

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -313,7 +313,7 @@ namespace esphome
     protected:
 
       // --- setter ---
-      
+
       void reset_errors_(bool filters, bool errors)
       {
         uint8_t reset_cmd[CMD_RESET_AND_SELF_TEST_LENGTH] = {errors ? (uint8_t)1 : (uint8_t)0, 0, 0, filters ? (uint8_t)1 : (uint8_t)0};
@@ -352,7 +352,7 @@ namespace esphome
       }
 
       // --- TX functions ---
-      
+
       // Build TX-array
       void write_command_(const uint8_t command, const uint8_t *command_data, uint8_t command_data_length)
       {
@@ -412,7 +412,7 @@ namespace esphome
         idx_txBuffer_u8++;
         txBuffer_au8[idx_txBuffer_u8] = 0x0F;
 
-        // todo for future use when ComfoAir and ComfoSense are both 
+        // todo for future use when ComfoAir and ComfoSense are both
         // connected to an individual UART on this ESP32:
         // Either send to CA or CS
         //
@@ -498,7 +498,7 @@ namespace esphome
       }
 
       // --- RX functions ---
-      
+
       rx_status checkRx_(uint8_t rxBuffer[], uint8_t *index_u8, uint8_t rc)
       {
         /* Manage and analyze rx bytes.
@@ -1161,7 +1161,7 @@ namespace esphome
       }
 
       // --- getter ---
-      
+
       void get_fan_status_()
       {
         if (intake_fan_speed != nullptr ||

--- a/components/comfoair/comfoair.h
+++ b/components/comfoair/comfoair.h
@@ -1,1517 +1,1846 @@
 #pragma once
 
 #include "esphome.h"
-#include "esphome/core/component.h"
-#include "esphome/components/uart/uart.h"
+#include "esphome/components/button/button.h"
 #include "esphome/components/climate/climate.h"
 #include "esphome/components/climate/climate_mode.h"
 #include "esphome/components/climate/climate_traits.h"
-#include "esphome/components/sensor/sensor.h"
-#include "esphome/components/select/select.h"
-#include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/number/number.h"
-#include "esphome/components/button/button.h"
+#include "esphome/components/select/select.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
 #include "registers.h"
+
+#include <algorithm>
 
 namespace esphome
 {
-  namespace comfoair
+namespace comfoair
+{
+
+// These are the possible status of the two receive functions for CA and CS
+typedef enum
+{
+  RX_STATUS_DEFAULT,                   // default (should not happen. coding error?)
+  RX_STATUS_RECEIVED_ACK,              // ACK received
+  RX_STATUS_RECEIVED_MESSAGE,          // message received
+  RX_STATUS_RECEIVED_INVALID_MESSAGE,  // invalid message received (rx error)
+  RX_STATUS_RECEIVED_START_OF_MESSAGE, // found rx-Start and adjusted buffer accordingly (just 4 info. no error.)
+  RX_STATUS_WRAPPED_BUFFER_INDEX       // wrapped buffer index (just 4 info. no error.)
+} rx_status;
+
+static const uint8_t COMFOAIR_MIN_SUPPORTED_TEMP = 12;
+static const uint8_t COMFOAIR_MAX_SUPPORTED_TEMP = 29;
+static const float COMFOAIR_SUPPORTED_TEMP_STEP = 0.5f;
+static const uint8_t MAX_MESSAGE_SIZE = 70U;
+// Reserve enough room for start/stop markers, command, length, and a
+// worst-case escaped checksum in addition to a fully escaped payload.
+static const uint8_t MAX_PROTOCOL_DATA_SIZE = (MAX_MESSAGE_SIZE - 9U) / 2U;
+
+static const char *TAG = "comfoair";
+
+class ComfoAirComponent;
+
+class ComfoAirSizeSelect : public select::Select
+{
+public:
+  void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
+
+protected:
+  void control(const std::string &value) override;
+
+private:
+  ComfoAirComponent *parent_{nullptr};
+};
+
+class ComfoAirNumber : public number::Number
+{
+public:
+  void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
+
+protected:
+  void control(float value) override;
+
+private:
+  ComfoAirComponent *parent_{nullptr};
+};
+
+class ComfoAirSyncButton : public button::Button
+{
+public:
+  void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
+
+protected:
+  void press_action() override;
+
+private:
+  ComfoAirComponent *parent_{nullptr};
+};
+
+class ComfoAirComponent : public climate::Climate, public PollingComponent, public uart::UARTDevice
+{
+  friend class ComfoAirSizeSelect;
+  friend class ComfoAirNumber;
+  friend class ComfoAirSyncButton;
+
+public:
+  // Poll every 2000ms (previously 600ms)
+  ComfoAirComponent() : Climate(), PollingComponent(2000), UARTDevice() {}
+
+  // Return the traits of this controller.
+  climate::ClimateTraits traits() override
   {
-
-    static const char *TAG = "comfoair";
-
-    class ComfoAirComponent;
-
-    class ComfoAirSizeSelect : public select::Select
-    {
-    public:
-      void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
-
-    protected:
-      void control(const std::string &value) override;
-
-    private:
-      ComfoAirComponent *parent_{nullptr};
-    };
-
-    class ComfoAirNumber : public number::Number
-    {
-    public:
-      void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
-
-    protected:
-      void control(float value) override;
-
-    private:
-      ComfoAirComponent *parent_{nullptr};
-    };
-
-    class ComfoAirSyncButton : public button::Button
-    {
-    public:
-      void set_parent(ComfoAirComponent *parent) { this->parent_ = parent; }
-
-    protected:
-      void press_action() override;
-
-    private:
-      ComfoAirComponent *parent_{nullptr};
-    };
-
-    class ComfoAirComponent : public climate::Climate, public PollingComponent, public uart::UARTDevice
-    {
-      friend class ComfoAirSizeSelect;
-      friend class ComfoAirSyncButton;
-      friend class ComfoAirNumber;
-
-    public:
-      // Poll every 600ms
-      ComfoAirComponent() : Climate(),
-                            PollingComponent(600),
-                            UARTDevice() {}
-
-      /// Return the traits of this controller.
-      climate::ClimateTraits traits() override
-      {
-        auto traits = climate::ClimateTraits();
+    auto traits = climate::ClimateTraits();
     traits.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
-        traits.set_supported_modes({climate::CLIMATE_MODE_FAN_ONLY});
+    traits.set_supported_modes({climate::CLIMATE_MODE_FAN_ONLY});
     traits.clear_feature_flags(climate::CLIMATE_REQUIRES_TWO_POINT_TARGET_TEMPERATURE);
     traits.clear_feature_flags(climate::CLIMATE_SUPPORTS_ACTION);
-        traits.set_visual_min_temperature(12);
-        traits.set_visual_max_temperature(29);
-        traits.set_visual_temperature_step(1);
+    traits.set_visual_min_temperature(COMFOAIR_MIN_SUPPORTED_TEMP);
+    traits.set_visual_max_temperature(COMFOAIR_MAX_SUPPORTED_TEMP);
+    traits.set_visual_temperature_step(COMFOAIR_SUPPORTED_TEMP_STEP);
     traits.set_supported_fan_modes({
-      climate::CLIMATE_FAN_LOW,
-      climate::CLIMATE_FAN_MEDIUM,
-      climate::CLIMATE_FAN_HIGH,
-      climate::CLIMATE_FAN_OFF,
+        climate::CLIMATE_FAN_AUTO,
+        climate::CLIMATE_FAN_LOW,
+        climate::CLIMATE_FAN_MEDIUM,
+        climate::CLIMATE_FAN_HIGH,
+        climate::CLIMATE_FAN_OFF,
     });
-        return traits;
+    return traits;
+  }
+
+  // Override control to change settings of the climate device.
+  void control(const climate::ClimateCall &call) override
+  {
+    if (call.get_fan_mode().has_value())
+    {
+      int level;
+
+      fan_mode = *call.get_fan_mode();
+      switch (fan_mode.value())
+      {
+      case climate::CLIMATE_FAN_HIGH:
+        level = 0x04;
+        break;
+      case climate::CLIMATE_FAN_MEDIUM:
+        level = 0x03;
+        break;
+      case climate::CLIMATE_FAN_LOW:
+        level = 0x02;
+        break;
+      case climate::CLIMATE_FAN_OFF:
+        level = 0x01;
+        break;
+      case climate::CLIMATE_FAN_AUTO:
+        level = 0x00;
+        break;
+      case climate::CLIMATE_FAN_ON:
+      case climate::CLIMATE_FAN_MIDDLE:
+      case climate::CLIMATE_FAN_DIFFUSE:
+      default:
+        level = -1;
+        break;
       }
 
-      /// Override control to change settings of the climate device.
-      void control(const climate::ClimateCall &call) override
+      if (level >= 0)
       {
-        if (call.get_fan_mode().has_value())
-        {
-          int level;
+        set_level_(level);
+      }
+    }
+    if (call.get_target_temperature().has_value())
+    {
+      target_temperature = *call.get_target_temperature();
+      set_comfort_temperature_(target_temperature);
+    }
 
-          fan_mode = *call.get_fan_mode();
-          switch (fan_mode.value())
-          {
-          case climate::CLIMATE_FAN_HIGH:
-            level = 0x04;
-            break;
-          case climate::CLIMATE_FAN_MEDIUM:
-            level = 0x03;
-            break;
-          case climate::CLIMATE_FAN_LOW:
-            level = 0x02;
-            break;
-          case climate::CLIMATE_FAN_OFF:
-            level = 0x01;
-            break;
-        case climate::CLIMATE_FAN_ON:
-        case climate::CLIMATE_FAN_MIDDLE:
-        case climate::CLIMATE_FAN_DIFFUSE:
-        default:
-          level = -1;
-            break;
-          }
+    publish_state();
+  }
 
-          if (level >= 0)
-          {
-            set_level_(level);
-          }
-        }
-        if (call.get_target_temperature().has_value())
-        {
-          target_temperature = *call.get_target_temperature();
-          set_comfort_temperature_(target_temperature);
-        }
+  void dump_config() override
+  {
+    uint8_t *p;
+    ESP_LOGCONFIG(TAG, "ComfoAir:");
+    // LOG_UPDATE_INTERVAL(this);
+    p = bootloader_version_;
+    ESP_LOGCONFIG(TAG, "  Bootloader %.10s v%0d.%02d b%2d", p + 3, *p, *(p + 1), *(p + 2));
+    p = firmware_version_;
+    ESP_LOGCONFIG(TAG, "  Firmware %.10s v%0d.%02d b%2d", p + 3, *p, *(p + 1), *(p + 2));
+    p = connector_board_version_;
+    ESP_LOGCONFIG(TAG, "  Connector Board %.10s v%0d.%02d", p + 2, *p, *(p + 1));
 
-        publish_state();
+    if (*(p + 12) != 0)
+    {
+      ESP_LOGCONFIG(TAG, "  CC-Ease v%0d.%02d", *(p + 12) >> 4, *(p + 12) & 0x0f);
+    }
+    if (*(p + 13) != 0)
+    {
+      ESP_LOGCONFIG(TAG, "  CC-Luxe v%0d.%02d", *(p + 13) >> 4, *(p + 13) & 0x0f);
+    }
+    check_uart_settings(9600);
+  }
+
+  void update() override
+  {
+    ESP_LOGD(TAG, "Component update: %d", update_counter_);
+    switch (update_counter_)
+    {
+    case -4:
+      write_command_(CMD_GET_BOOTLOADER_VERSION, nullptr, 0);
+      break;
+    case -3:
+      write_command_(CMD_GET_FIRMWARE_VERSION, nullptr, 0);
+      break;
+    case -2:
+      write_command_(CMD_GET_CONNECTOR_BOARD_VERSION, nullptr, 0);
+      break;
+    case -1:
+      write_command_(CMD_GET_STATUS, nullptr, 0);
+      break;
+    case 0:
+      get_fan_status_();
+      break;
+    case 1:
+      get_valve_status_();
+      break;
+    case 2:
+      get_sensor_data_();
+      break;
+    case 3:
+      get_ventilation_level_();
+      break;
+    case 4:
+      get_temperatures_();
+      break;
+    case 5:
+      get_error_status_();
+      break;
+    case 6:
+      get_bypass_control_status_();
+      break;
+    case 7:
+      get_operation_hours_();
+      break;
+    case 8:
+      get_preheating_status_();
+      break;
+    case 9:
+      get_time_delay_();
+      break;
+    default:
+      ESP_LOGI(TAG, "Component update: %d", update_counter_);
+      break;
+    }
+
+    update_counter_++;
+    if (update_counter_ > 9) // num_update_counter_elements_
+    {
+      update_counter_ = 0;
+    }
+  }
+
+  void loop() override
+  {
+    /*
+    TX:
+    1. Build TX-array:
+      - 2 Byte Command
+      - 1 Byte Size = amount of data bytes (0...n)
+      - 0...n data bytes = payload data (without doubled 0x07 bytes yet)
+    2. Calculate and append checksum across TX-array.
+    3. transmit function:
+      - transmit 2 Byte "START" (0x07 0xF0)
+      - transmit TX-array
+        - transmit byte 1 to byte 3
+        - transmit byte 4 to byte [3.byte + 3] while transmitting each 0x07 twice.
+        - transmit byte [3.byte + 4].
+      - transmit 2 Byte "STOP" (0x07 0x0F)
+
+    RX:
+    1. read uart byte by byte into RX-array
+      - search for ACK (0x07 0xF3) -> announce new ACK
+      - search for START (0x07 0xF0) and STOP (0x07 0x0F) -> announce new message
+    2. remove START, STOP and doubled 0x07 from new RX-array to get clean data.
+    3. calculate and verify checksum of new message.
+      - send ACK?
+    4. process RX data
+    */
+
+    // CA350
+    // caRxSerial();       // receive ACKs and messages from CA350
+
+    while (available() != 0)
+    {
+      uint8_t rx_byte_u8;
+
+      // fetch byte for RX buffer and process it by readRx()
+      read_byte(&rx_byte_u8);
+
+      switch (checkRx_(caRxBuffer_au8, &caRxIdx_u8, rx_byte_u8))
+      {
+      case RX_STATUS_DEFAULT:
+        break;
+      case RX_STATUS_RECEIVED_ACK:
+        ESP_LOGVV(TAG, "RX: ACK");
+        // caProcessNewACK(); // do something if an ACK is received
+        break;
+      case RX_STATUS_RECEIVED_MESSAGE:
+        ESP_LOGVV(TAG, "RX: message cmd: %02X", caRxBuffer_au8[1]);
+        // acknowledge message
+        txACK_();
+        // at this point caRxBuffer_au8 consists of
+        // 2-byte command, length, data and checksum.
+        // caProcessNewData(caRxBuffer); // do something with received message
+        parseRxMessage_(caRxBuffer_au8);
+        break;
+      case RX_STATUS_RECEIVED_INVALID_MESSAGE:
+        ESP_LOGW(TAG, "RX: Invalid checksum (from CA350).");
+        break;
+      case RX_STATUS_RECEIVED_START_OF_MESSAGE:
+      case RX_STATUS_WRAPPED_BUFFER_INDEX:
+      default:
+        break;
+      }
+    }
+
+    // ComfoSense
+    // csRxSerial();       // receive ACKs and messages from ComfoSense
+  }
+
+  float get_setup_priority() const override { return setup_priority::DATA; }
+
+  void reset_errors(void) { reset_errors_(false, true); }
+
+  void reset_filters(void) { reset_errors_(true, false); }
+
+  // Backward-compatible names used by existing YAML configurations.
+  void error_reset(void) { reset_errors(); }
+  void filter_reset(void) { reset_filters(); }
+
+  void set_name(const char *value) { name = value; }
+  void set_name(const char *value, uint32_t name_hash)
+  {
+    (void)name_hash;
+    name = value;
+  }
+  void set_uart_component(uart::UARTComponent *parent) { set_uart_parent(parent); }
+  bool set_unit_size(uint8_t raw_size);
+  void set_size_select(ComfoAirSizeSelect *size_select);
+
+  void set_level(int level) { set_level_(level); }
+  void set_comfort_temperature(float temperature) { set_comfort_temperature_(temperature); }
+
+protected:
+  // --- setter ---
+
+  void reset_errors_(bool filters, bool errors)
+  {
+    uint8_t reset_cmd[CMD_RESET_AND_SELF_TEST_LENGTH] = {errors ? (uint8_t)1 : (uint8_t)0, 0, 0,
+                                                         filters ? (uint8_t)1 : (uint8_t)0};
+    write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
+  }
+
+  void set_level_(int level)
+  {
+    if (level < 0 || level > 4)
+    {
+      ESP_LOGI(TAG, "Ignoring invalid level request: %i", level);
+      return;
+    }
+
+    ESP_LOGI(TAG, "Setting level to: %i", level);
+    {
+      uint8_t command[CMD_SET_LEVEL_LENGTH] = {(uint8_t)level};
+      write_command_(CMD_SET_LEVEL, command, sizeof(command));
+    }
+  }
+
+  void set_comfort_temperature_(float temperature)
+  {
+    if (temperature < COMFOAIR_MIN_SUPPORTED_TEMP || temperature > COMFOAIR_MAX_SUPPORTED_TEMP)
+    {
+      ESP_LOGI(TAG, "Ignoring invalid temperature request: %.1f", temperature);
+      return;
+    }
+
+    ESP_LOGI(TAG, "Setting temperature to: %.1f", temperature);
+    {
+      uint8_t command[CMD_SET_COMFORT_TEMPERATURE_LENGTH] = {(uint8_t)((temperature + 20.0f) * 2.0f)};
+      write_command_(CMD_SET_COMFORT_TEMPERATURE, command, sizeof(command));
+    }
+  }
+
+  void set_fan_percentages()
+  {
+    if (return_air_level_absent == nullptr || return_air_level_low == nullptr || return_air_level_medium == nullptr ||
+        return_air_level_high == nullptr || supply_air_level_absent == nullptr || supply_air_level_low == nullptr ||
+        supply_air_level_medium == nullptr || supply_air_level_high == nullptr)
+    {
+      ESP_LOGW(TAG, "Cannot sync: one or more fan-level entities are missing");
+      return;
+    }
+
+    uint8_t data[CMD_SET_VENTILATION_LEVEL_LENGTH];
+    data[0] = static_cast<uint8_t>(std::clamp(static_cast<int>(return_air_level_absent->state), 15, 95));
+    data[1] = static_cast<uint8_t>(std::clamp(static_cast<int>(return_air_level_low->state), 15, 95));
+    data[2] = static_cast<uint8_t>(std::clamp(static_cast<int>(return_air_level_medium->state), 15, 95));
+    data[3] = static_cast<uint8_t>(std::clamp(static_cast<int>(supply_air_level_absent->state), 15, 95));
+    data[4] = static_cast<uint8_t>(std::clamp(static_cast<int>(supply_air_level_low->state), 15, 95));
+    data[5] = static_cast<uint8_t>(std::clamp(static_cast<int>(supply_air_level_medium->state), 15, 95));
+    data[6] = static_cast<uint8_t>(std::clamp(static_cast<int>(return_air_level_high->state), 15, 95));
+    data[7] = static_cast<uint8_t>(std::clamp(static_cast<int>(supply_air_level_high->state), 15, 95));
+    data[8] = 0x00;
+
+    ESP_LOGD(TAG, "Setting fan speed percentages");
+    write_command_(CMD_SET_VENTILATION_LEVEL, data, sizeof(data));
+  }
+
+  // --- TX functions ---
+
+  // Build TX-array
+  void write_command_(const uint8_t command, const uint8_t *command_data, uint8_t command_data_length)
+  {
+    if (command_data_length > MAX_PROTOCOL_DATA_SIZE)
+    {
+      ESP_LOGW(TAG, "Command 0x%02X payload is too large: %u", command, command_data_length);
+      return;
+    }
+
+    uint8_t message_au8_au8[MAX_MESSAGE_SIZE]{};
+    message_au8_au8[0] = 0x00;
+    message_au8_au8[1] = command;
+    message_au8_au8[2] = command_data_length;
+    for (uint8_t idx_u8 = 0; idx_u8 < command_data_length; idx_u8++)
+    {
+      message_au8_au8[3 + idx_u8] = command_data[idx_u8];
+    }
+    txMessage_(message_au8_au8);
+  }
+
+  // add prefix, second 0x07, checksum and postfix and transmit that data.
+  void txMessage_(uint8_t message_au8[] /*, tx_serial txPort_en */)
+  {
+    // add 2 bytes "START"
+    // copy "COMMAND" and "SIZE"
+    // copy "DATA" and double each 0x07 in data area
+    // add "CHECKSUM" and escape it when needed
+    // add 2 bytes "STOP"
+    // transmit everything to Serial
+
+    ESP_LOGVV(TAG, "TX: cmd: %02X size: %u", message_au8[1], message_au8[2]);
+
+    uint8_t txBuffer_au8[MAX_MESSAGE_SIZE]; // TX buffer
+    // Start
+    txBuffer_au8[0] = 0x07;
+    txBuffer_au8[1] = 0xF0;
+    // Command
+    txBuffer_au8[2] = message_au8[0];
+    txBuffer_au8[3] = message_au8[1];
+    // Size
+    txBuffer_au8[4] = message_au8[2];
+    // Data
+    uint8_t idx_message_u8 = 3U;
+    uint8_t idx_txBuffer_u8 = 5U;
+    while (idx_message_u8 < message_au8[2] + 3)
+    {
+      // copy current byte
+      txBuffer_au8[idx_txBuffer_u8] = message_au8[idx_message_u8];
+      if (message_au8[idx_message_u8] == 0x07U)
+      {
+        // repeat 0x07 in TX
+        idx_txBuffer_u8++;
+        txBuffer_au8[idx_txBuffer_u8] = 0x07U;
+      }
+      idx_message_u8++;
+      idx_txBuffer_u8++;
+    }
+    // Checksum
+    const uint8_t checksum = calcChecksum_(message_au8);
+    txBuffer_au8[idx_txBuffer_u8] = checksum;
+    if (checksum == COMMAND_PREFIX)
+    {
+      idx_txBuffer_u8++;
+      txBuffer_au8[idx_txBuffer_u8] = checksum;
+    }
+    idx_txBuffer_u8++;
+    // Stop
+    txBuffer_au8[idx_txBuffer_u8] = 0x07;
+    idx_txBuffer_u8++;
+    txBuffer_au8[idx_txBuffer_u8] = 0x0F;
+
+    // todo for future use when ComfoAir and ComfoSense are both
+    // connected to an individual UART on this ESP32:
+    // Either send to CA or CS
+    //
+    // transmit
+    // idx_message_u8 = 0U;
+    // switch (txPort_en)
+    // {
+    // case SERIAL_0_PC:
+    //   while (idx_message_u8 <= idx_txBuffer_u8)
+    //   {
+    //     Serial.write(txBuffer_au8[idx_message_u8]);
+    //     idx_message_u8++;
+    //   }
+    //   break;
+    // case SERIAL_1_ComfoAir:
+    //   while (idx_message_u8 <= idx_txBuffer_u8)
+    //   {
+    //     Serial1.write(txBuffer_au8[idx_message_u8]);
+    //     idx_message_u8++;
+    //   }
+    //   break;
+    // case SERIAL_2_ComfoSense:
+    //   while (idx_message_u8 <= idx_txBuffer_u8)
+    //   {
+    //     Serial2.write(txBuffer_au8[idx_message_u8]);
+    //     idx_message_u8++;
+    //   }
+    //   break;
+    // default:
+    //   break;
+    // }
+    idx_txBuffer_u8++;
+    write_array(txBuffer_au8, idx_txBuffer_u8);
+    flush();
+  }
+
+  void txACK_(/* tx_serial txPort_en */)
+  {
+    // send an ACK to Serial
+
+    // todo transmit
+    // switch (txPort_en)
+    // {
+    // case SERIAL_0_PC:
+    //   Serial.write(0x07);
+    //   Serial.write(0xF3);
+    //   break;
+    // case SERIAL_1_ComfoAir:
+    //   Serial1.write(0x07);
+    //   Serial1.write(0xF3);
+    //   break;
+    // case SERIAL_2_ComfoSense:
+    //   Serial2.write(0x07);
+    //   Serial2.write(0xF3);
+    //   break;
+    // default:
+    //   break;
+    // }
+
+    write_byte(COMMAND_PREFIX);
+    write_byte(COMMAND_HEAD_ACK);
+    flush();
+  }
+
+  // RX & TX common checksum function
+  uint8_t calcChecksum_(uint8_t message_au8[])
+  {
+    // Calculates checksum.
+    // Doubled 0x07 has to be removed beforehand!
+    uint16_t sum = 0xADU; // = 173
+    uint8_t idx = 0U;
+
+    while (idx <= message_au8[2] + 2)
+    {
+      // sum up all message bytes including
+      // "Kommando", "Anzahl Daten" and "Daten"
+      sum = sum + message_au8[idx];
+      idx++;
+    }
+
+    // return only LSB of sum
+    return ((uint8_t)sum);
+  }
+
+  // --- RX functions ---
+
+  rx_status checkRx_(uint8_t rxBuffer[], uint8_t *index_u8, uint8_t rc)
+  {
+    /* Manage and analyze rx bytes.
+      return indicates ACK or MESSAGE.
+    */
+    rx_status return_val = RX_STATUS_DEFAULT;
+
+    // store received byte in array
+    rxBuffer[*index_u8] = rc;
+
+    // analyze array
+
+    // Two possible message beginnings:
+    // 1. 0x07 0xF3 -> is an ACK
+    // 2. 0x07 0xF0 -> is the beginning of an actual message which has to end with 0x07 0x0F
+
+    if (*index_u8 == 1U && rxBuffer[0] == 0x07 && rxBuffer[1] == 0xF3)
+    {
+      // received ACK
+      return_val = RX_STATUS_RECEIVED_ACK;
+      *index_u8 = 0U;
+    }
+    else if (*index_u8 > 1U && rxBuffer[*index_u8 - 2] != 0x07 && rxBuffer[*index_u8 - 1] == 0x07 &&
+             rxBuffer[*index_u8] == 0xF3)
+    {
+      // received ACK
+      return_val = RX_STATUS_RECEIVED_ACK;
+      *index_u8 = 0U;
+    }
+    else if (*index_u8 > 1U && rxBuffer[*index_u8 - 2] != 0x07 && rxBuffer[*index_u8 - 1] == 0x07 &&
+             rxBuffer[*index_u8] == 0xF0)
+    {
+      // This has to be the start of a new message.
+      //
+      // This assumption is true as long as there is no Kommando 0x.. 0x07
+      // followed by a size of 0xF0. But afaik the Kommando 0x00 0x07 is of
+      // size 3 and other 0x.. 0x07 commands are unknown.
+      rxBuffer[0] = 0x07;
+      rxBuffer[1] = 0xF0;
+      *index_u8 = 2U;
+      return_val = RX_STATUS_RECEIVED_START_OF_MESSAGE;
+    }
+    else if (*index_u8 == 4U && rxBuffer[0] == 0x07 && rxBuffer[1] == 0xF0 && rxBuffer[4] > MAX_PROTOCOL_DATA_SIZE)
+    {
+      ESP_LOGW(TAG, "RX payload is too large: %u", rxBuffer[4]);
+      return_val = RX_STATUS_RECEIVED_INVALID_MESSAGE;
+      *index_u8 = 0U;
+    }
+    else if (*index_u8 >= 7U && rxBuffer[0] == 0x07 && rxBuffer[1] == 0xF0 && rxBuffer[*index_u8 - 1] == 0x07 &&
+             rxBuffer[*index_u8] == 0x0F)
+    {
+      // new message received:
+      // remove "START" and "STOP" plus
+      // eliminate double 0x07 within data area
+      const uint8_t checksum_index = isolateRxMessage_(rxBuffer, *index_u8);
+      const uint8_t expected_checksum_index = rxBuffer[2] + 3U;
+
+      if (checksum_index != expected_checksum_index)
+      {
+        ESP_LOGW(TAG, "RX length mismatch for command 0x%02X: expected %u data bytes", rxBuffer[1], rxBuffer[2]);
+        return_val = RX_STATUS_RECEIVED_INVALID_MESSAGE;
+        *index_u8 = 0U;
+      }
+      else if (calcChecksum_(rxBuffer) == rxBuffer[checksum_index])
+      {
+        // message is valid
+        return_val = RX_STATUS_RECEIVED_MESSAGE;
+        *index_u8 = 0U;
+      }
+      else
+      {
+        // message invalid
+        return_val = RX_STATUS_RECEIVED_INVALID_MESSAGE;
+        ESP_LOGD(TAG, "RX checksum mismatch for command 0x%02X: calculated %02X, received %02X", rxBuffer[1],
+                 calcChecksum_(rxBuffer), rxBuffer[checksum_index]);
+        *index_u8 = 0U;
+      }
+    }
+    else
+    {
+      return_val = RX_STATUS_WRAPPED_BUFFER_INDEX;
+      *index_u8 = (1 + *index_u8) % MAX_MESSAGE_SIZE;
+    }
+    return return_val;
+  }
+
+  uint8_t isolateRxMessage_(uint8_t rxBuffer[], uint8_t size)
+  {
+    // remove "START" (2 bytes)
+    // copy "COMMAND" and "SIZE" (3 bytes)
+    // copy "DATA" while removing doubled 0x07 in data area if applicable
+    // copy "Checksum"
+    // remove/ignore "STOP" (2 bytes)
+    // return resulting size of array
+    uint8_t read_idx_u8 = 2U; // skip/remove/ignore "START"-bytes
+    uint8_t write_idx_u8 = 0U;
+
+    // copy "COMAND" and "SIZE"
+    while (read_idx_u8 < 5U)
+    {
+      rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+      read_idx_u8++;
+      write_idx_u8++;
+    }
+
+    // copy "DATA" while removing doubled 0x07 in data area if applicable
+    while (((write_idx_u8 - 3U) < rxBuffer[2]) && (read_idx_u8 < size - 2))
+    {
+      rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+      if ((rxBuffer[read_idx_u8] == 0x07U) && (rxBuffer[read_idx_u8 + 1U] == 0x07U))
+      {
+        // skip next byte which is expected to be 0x07 according to reverse
+        // engineered protocol
+        read_idx_u8++;
+      }
+      read_idx_u8++;
+      write_idx_u8++;
+    }
+
+    // copy "Checksum". Some implementations send a checksum of 0x07 raw,
+    // while others escape it like payload data. Accept both forms.
+    if (read_idx_u8 == size - 3U && rxBuffer[read_idx_u8] == COMMAND_PREFIX &&
+        rxBuffer[read_idx_u8 + 1U] == COMMAND_PREFIX)
+    {
+      rxBuffer[write_idx_u8] = COMMAND_PREFIX;
+    }
+    else if (read_idx_u8 == size - 2U)
+    {
+      rxBuffer[write_idx_u8] = rxBuffer[read_idx_u8];
+    }
+    else
+    {
+      return MAX_MESSAGE_SIZE;
+    }
+    // return resulting size of array
+    return (write_idx_u8);
+  }
+
+  void parseRxMessage_(uint8_t *message_au8)
+  {
+    status_clear_warning();
+    // message_au8[0] = 0x00
+    // message_au8[1] = command byte
+    // message_au8[2] = data_length
+    // message_au8[3] = first byte of data
+
+    uint8_t msg_command_u8 = message_au8[COMMAND_IDX_MSG_ID - 2]; // -2 because prefix is removed from data
+    uint8_t msg_length_u8 = message_au8[COMMAND_IDX_PROTOCOL_LENGTH - 2];
+    uint8_t *msg_data = &message_au8[COMMAND_IDX_PROTOCOL_DATA_AREA - 2];
+
+    switch (msg_command_u8)
+    {
+    case RES_GET_BOOTLOADER_VERSION:
+      memcpy(bootloader_version_, msg_data, std::min<size_t>(msg_length_u8, sizeof(bootloader_version_)));
+      break;
+    case RES_GET_FIRMWARE_VERSION:
+      memcpy(firmware_version_, msg_data, std::min<size_t>(msg_length_u8, sizeof(firmware_version_)));
+      break;
+    case RES_GET_CONNECTOR_BOARD_VERSION:
+      memcpy(connector_board_version_, msg_data, std::min<size_t>(msg_length_u8, sizeof(connector_board_version_)));
+      break;
+    case RES_GET_FAN_STATUS:
+    {
+      if (intake_fan_speed != nullptr)
+      {
+        intake_fan_speed->publish_state(msg_data[0]);
+      }
+      if (exhaust_fan_speed != nullptr)
+      {
+        exhaust_fan_speed->publish_state(msg_data[1]);
+      }
+      if (intake_fan_speed_rpm != nullptr)
+      {
+        const uint16_t intake_period = static_cast<uint16_t>(msg_data[2] << 8 | msg_data[3]);
+        intake_fan_speed_rpm->publish_state(intake_period == 0 ? 0 : static_cast<int>(1875000.0f / intake_period));
+      }
+      if (exhaust_fan_speed_rpm != nullptr)
+      {
+        const uint16_t exhaust_period = static_cast<uint16_t>(msg_data[4] << 8 | msg_data[5]);
+        exhaust_fan_speed_rpm->publish_state(exhaust_period == 0 ? 0 : static_cast<int>(1875000.0f / exhaust_period));
+      }
+      break;
+    }
+    case RES_GET_VALVE_STATUS:
+    {
+      if (bypass_valve != nullptr)
+      {
+        bypass_valve->publish_state(msg_data[0]);
+      }
+      if (bypass_valve_open != nullptr)
+      {
+        bypass_valve_open->publish_state(msg_data[0] != 0);
+      }
+      // Value 2 means unknown; do not publish it as a false closed state.
+      if (preheating_state != nullptr && msg_data[1] <= 1)
+      {
+        preheating_state->publish_state(msg_data[1] == 1);
+      }
+      if (motor_current_bypass != nullptr)
+      {
+        motor_current_bypass->publish_state(msg_data[2]);
+      }
+      if (motor_current_preheating != nullptr)
+      {
+        motor_current_preheating->publish_state(msg_data[3]);
+      }
+      break;
+    }
+    case RES_GET_BYPASS_CONTROL_STATUS:
+    {
+      if (bypass_factor != nullptr)
+      {
+        bypass_factor->publish_state(msg_data[2]);
+      }
+      if (bypass_step != nullptr)
+      {
+        bypass_step->publish_state(msg_data[3]);
+      }
+      if (bypass_correction != nullptr)
+      {
+        bypass_correction->publish_state(msg_data[4]);
+      }
+      if (summer_mode != nullptr)
+      {
+        summer_mode->publish_state(msg_data[6] != 0);
+      }
+      break;
+    }
+    case RES_GET_TEMPERATURE_STATUS:
+    {
+      // T1 / outside air
+      if (outside_air_temperature != nullptr)
+      {
+        outside_air_temperature->publish_state((float)msg_data[0] / 2.0f - 20.0f);
+      }
+      // T2 / supply air
+      if (supply_air_temperature != nullptr)
+      {
+        supply_air_temperature->publish_state((float)msg_data[1] / 2.0f - 20.0f);
+      }
+      // T3 / return air
+      if (return_air_temperature != nullptr)
+      {
+        return_air_temperature->publish_state((float)msg_data[2] / 2.0f - 20.0f);
+      }
+      // T4 / exhaust air
+      if (exhaust_air_temperature != nullptr)
+      {
+        exhaust_air_temperature->publish_state((float)msg_data[3] / 2.0f - 20.0f);
+      }
+      break;
+    }
+    case RES_GET_SENSOR_DATA:
+    {
+      if (enthalpy_temperature != nullptr)
+      {
+        enthalpy_temperature->publish_state((float)msg_data[0] / 2.0f - 20.0f);
+      }
+      break;
+    }
+    case RES_GET_VENTILATION_LEVEL:
+    {
+      ESP_LOGD(TAG, "Level %02X", msg_data[8]);
+      ESP_LOGV(
+          TAG, "Off ab %i - Off zu %i - Low ab %i - Low zu %i - Middle ab %i - Middle zu %i - High ab %i - High zu %i",
+          msg_data[0], msg_data[3], msg_data[1], msg_data[4], msg_data[2], msg_data[5], msg_data[10], msg_data[11]);
+
+      if (return_air_level != nullptr)
+      {
+        return_air_level->publish_state(msg_data[6]);
+      }
+      if (supply_air_level != nullptr)
+      {
+        supply_air_level->publish_state(msg_data[7]);
       }
 
-      void dump_config() override
+      if (ventilation_level != nullptr)
       {
-        uint8_t *p;
-        ESP_LOGCONFIG(TAG, "ComfoAir:");
-        // LOG_UPDATE_INTERVAL(this);
-        p = bootloader_version_;
-        ESP_LOGCONFIG(TAG, "  Bootloader %.10s v%0d.%02d b%2d", p + 3, *p, *(p + 1), *(p + 2));
-        p = firmware_version_;
-        ESP_LOGCONFIG(TAG, "  Firmware %.10s v%0d.%02d b%2d", p + 3, *p, *(p + 1), *(p + 2));
-        p = connector_board_version_;
-        ESP_LOGCONFIG(TAG, "  Connector Board %.10s v%0d.%02d", p + 2, *p, *(p + 1));
-
-        if (*(p + 12) != 0)
-        {
-          ESP_LOGCONFIG(TAG, "  CC-Ease v%0d.%02d", *(p + 12) >> 4, *(p + 12) & 0x0f);
-        }
-        if (*(p + 13) != 0)
-        {
-          ESP_LOGCONFIG(TAG, "  CC-Luxe v%0d.%02d", *(p + 13) >> 4, *(p + 13) & 0x0f);
-        }
-        check_uart_settings(9600);
+        ventilation_level->publish_state(msg_data[8] == 0 ? 0 : msg_data[8] - 1);
       }
 
-      void update() override
+      // Fan Speed
+      switch (msg_data[8])
       {
-        switch (update_counter_)
+      case 0x00:
+        fan_mode = climate::CLIMATE_FAN_AUTO;
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case 0x01:
+        fan_mode = climate::CLIMATE_FAN_OFF;
+        mode = climate::CLIMATE_MODE_OFF;
+        break;
+      case 0x02:
+        fan_mode = climate::CLIMATE_FAN_LOW;
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case 0x03:
+        fan_mode = climate::CLIMATE_FAN_MEDIUM;
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      case 0x04:
+        fan_mode = climate::CLIMATE_FAN_HIGH;
+        mode = climate::CLIMATE_MODE_FAN_ONLY;
+        break;
+      }
+
+      if (return_air_level_absent != nullptr)
+        return_air_level_absent->publish_state(msg_data[0]);
+      if (return_air_level_low != nullptr)
+        return_air_level_low->publish_state(msg_data[1]);
+      if (return_air_level_medium != nullptr)
+        return_air_level_medium->publish_state(msg_data[2]);
+      if (return_air_level_high != nullptr)
+        return_air_level_high->publish_state(msg_data[10]);
+      if (supply_air_level_absent != nullptr)
+        supply_air_level_absent->publish_state(msg_data[3]);
+      if (supply_air_level_low != nullptr)
+        supply_air_level_low->publish_state(msg_data[4]);
+      if (supply_air_level_medium != nullptr)
+        supply_air_level_medium->publish_state(msg_data[5]);
+      if (supply_air_level_high != nullptr)
+        supply_air_level_high->publish_state(msg_data[11]);
+
+      publish_state();
+
+      // Supply air fan active (1 = active / 0 = inactive)
+      if (supply_fan_active != nullptr)
+      {
+        supply_fan_active->publish_state(msg_data[9] == 1);
+      }
+      break;
+    }
+    case RES_GET_FAULTS:
+    {
+      const uint8_t status = msg_data[8];
+      if (filter_status != nullptr)
+      {
+        filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
+      }
+      // Keep the binary sensor unknown when the protocol does not report a valid OK/full value.
+      if (filter_status_full != nullptr && status <= 1)
+      {
+        filter_status_full->publish_state(status == 1);
+      }
+      break;
+    }
+    case RES_GET_TEMPERATURES:
+    {
+      // comfort temperature
+      target_temperature = (float)msg_data[0] / 2.0f - 20.0f;
+      publish_state();
+
+      // T1 / outside air
+      if (outside_air_temperature != nullptr && msg_data[5] & 0x01)
+      {
+        outside_air_temperature->publish_state((float)msg_data[1] / 2.0f - 20.0f);
+      }
+      // T2 / supply air
+      if (supply_air_temperature != nullptr && msg_data[5] & 0x02)
+      {
+        supply_air_temperature->publish_state((float)msg_data[2] / 2.0f - 20.0f);
+      }
+      // T3 / exhaust air
+      if (return_air_temperature != nullptr && msg_data[5] & 0x04)
+      {
+        return_air_temperature->publish_state((float)msg_data[3] / 2.0f - 20.0f);
+        current_temperature = (float)msg_data[3] / 2.0f - 20.0f;
+      }
+      // T4 / continued air
+      if (exhaust_air_temperature != nullptr && msg_data[5] & 0x08)
+      {
+        exhaust_air_temperature->publish_state((float)msg_data[4] / 2.0f - 20.0f);
+      }
+      // EWT
+      if (ewt_temperature != nullptr && msg_data[5] & 0x10)
+      {
+        ewt_temperature->publish_state((float)msg_data[6] / 2.0f - 20.0f);
+      }
+      // reheating
+      if (reheating_temperature != nullptr && msg_data[5] & 0x20)
+      {
+        reheating_temperature->publish_state((float)msg_data[7] / 2.0f - 20.0f);
+      }
+      // kitchen hood
+      if (kitchen_hood_temperature != nullptr && msg_data[5] & 0x40)
+      {
+        kitchen_hood_temperature->publish_state((float)msg_data[8] / 2.0f - 20.0f);
+      }
+      break;
+    }
+    case RES_GET_STATUS:
+    {
+      if (preheating_present != nullptr)
+      {
+        preheating_present->publish_state(msg_data[0]);
+      }
+
+      if (bypass_present != nullptr)
+      {
+        bypass_present->publish_state(msg_data[1]);
+      }
+
+      if (type != nullptr)
+      {
+        type->publish_state(msg_data[2] == 1 ? "Left" : (msg_data[2] == 2 ? "Right" : "Unknown"));
+      }
+
+      publish_size_entities_(msg_data[3]);
+
+      if (options_present != nullptr)
+      {
+        options_present->publish_state(msg_data[4]);
+      }
+
+      if (fireplace_present != nullptr)
+      {
+        fireplace_present->publish_state(msg_data[4] & 0x01);
+      }
+
+      if (kitchen_hood_present != nullptr)
+      {
+        kitchen_hood_present->publish_state(msg_data[4] & 0x02);
+      }
+
+      if (postheating_present != nullptr)
+      {
+        postheating_present->publish_state(msg_data[4] & 0x04);
+      }
+
+      if (postheating_pwm_mode_present != nullptr)
+      {
+        postheating_pwm_mode_present->publish_state(msg_data[4] & 0x40);
+      }
+
+      if (p10_active != nullptr)
+      {
+        p10_active->publish_state(msg_data[6] & 0x01);
+      }
+
+      if (p11_active != nullptr)
+      {
+        p11_active->publish_state(msg_data[6] & 0x02);
+      }
+
+      if (p12_active != nullptr)
+      {
+        p12_active->publish_state(msg_data[6] & 0x04);
+      }
+
+      if (p13_active != nullptr)
+      {
+        p13_active->publish_state(msg_data[6] & 0x08);
+      }
+
+      if (p14_active != nullptr)
+      {
+        p14_active->publish_state(msg_data[6] & 0x10);
+      }
+
+      if (p15_active != nullptr)
+      {
+        p15_active->publish_state(msg_data[6] & 0x20);
+      }
+
+      if (p16_active != nullptr)
+      {
+        p16_active->publish_state(msg_data[6] & 0x40);
+      }
+
+      if (p17_active != nullptr)
+      {
+        p17_active->publish_state(msg_data[6] & 0x80);
+      }
+
+      if (p18_active != nullptr)
+      {
+        p18_active->publish_state(msg_data[7] & 0x01);
+      }
+
+      if (p19_active != nullptr)
+      {
+        p19_active->publish_state(msg_data[7] & 0x02);
+      }
+
+      if (p90_active != nullptr)
+      {
+        p90_active->publish_state(msg_data[8] & 0x01);
+      }
+
+      if (p91_active != nullptr)
+      {
+        p91_active->publish_state(msg_data[8] & 0x02);
+      }
+
+      if (p92_active != nullptr)
+      {
+        p92_active->publish_state(msg_data[8] & 0x04);
+      }
+
+      if (p93_active != nullptr)
+      {
+        p93_active->publish_state(msg_data[8] & 0x08);
+      }
+
+      if (p94_active != nullptr)
+      {
+        p94_active->publish_state(msg_data[8] & 0x10);
+      }
+
+      if (p95_active != nullptr)
+      {
+        p95_active->publish_state(msg_data[8] & 0x20);
+      }
+
+      if (p96_active != nullptr)
+      {
+        p96_active->publish_state(msg_data[8] & 0x40);
+      }
+
+      if (p97_active != nullptr)
+      {
+        p97_active->publish_state(msg_data[8] & 0x80);
+      }
+
+      if (enthalpy_present != nullptr)
+      {
+        enthalpy_present->publish_state(msg_data[9]);
+      }
+
+      if (ewt_present != nullptr)
+      {
+        ewt_present->publish_state(msg_data[10]);
+      }
+
+      if (msg_length_u8 >= 11)
+      {
+        status_payload_[0] = msg_data[0];
+        status_payload_[1] = msg_data[1];
+        status_payload_[2] = msg_data[2];
+        status_payload_[3] = msg_data[3];
+        status_payload_[4] = msg_data[4];
+        status_payload_[5] = msg_data[5];
+        status_payload_[6] = msg_data[9];
+        status_payload_[7] = msg_data[10];
+        status_payload_valid_ = true;
+      }
+      else
+      {
+        status_payload_valid_ = false;
+      }
+      break;
+    }
+    case RES_GET_OPERATION_HOURS:
+    {
+      if (level0_hours != nullptr)
+      {
+        level0_hours->publish_state((msg_data[0] << 16) | (msg_data[1] << 8) | msg_data[2]);
+      }
+
+      if (level1_hours != nullptr)
+      {
+        level1_hours->publish_state((msg_data[3] << 16) | (msg_data[4] << 8) | msg_data[5]);
+      }
+
+      if (level2_hours != nullptr)
+      {
+        level2_hours->publish_state((msg_data[6] << 16) | (msg_data[7] << 8) | msg_data[8]);
+      }
+
+      if (level3_hours != nullptr)
+      {
+        level3_hours->publish_state((msg_data[17] << 16) | (msg_data[18] << 8) | msg_data[19]);
+      }
+
+      if (frost_protection_hours != nullptr)
+      {
+        frost_protection_hours->publish_state((msg_data[9] << 8) | msg_data[10]);
+      }
+
+      if (bypass_open_hours != nullptr)
+      {
+        bypass_open_hours->publish_state((msg_data[13] << 8) | msg_data[14]);
+      }
+
+      if (preheating_hours != nullptr)
+      {
+        preheating_hours->publish_state((msg_data[11] << 8) | msg_data[12]);
+      }
+
+      if (filter_hours != nullptr)
+      {
+        filter_hours->publish_state((msg_data[15] << 8) | msg_data[16]);
+      }
+      break;
+    }
+    case RES_GET_PREHEATING_STATUS:
+    {
+      if (preheating_valve != nullptr)
+      {
+        std::string name_preheating_valve;
+        switch (msg_data[0])
         {
-        case -4:
-          write_command_(CMD_GET_BOOTLOADER_VERSION, nullptr, 0);
-          break;
-        case -3:
-          write_command_(CMD_GET_FIRMWARE_VERSION, nullptr, 0);
-          break;
-        case -2:
-          write_command_(CMD_GET_CONNECTOR_BOARD_VERSION, nullptr, 0);
-          break;
-        case -1:
-          write_command_(CMD_GET_STATUS, nullptr, 0);
-          break;
         case 0:
-          get_fan_status_();
+          name_preheating_valve = "Closed";
           break;
+
         case 1:
-          get_valve_status_();
+          name_preheating_valve = "Open";
           break;
+
+        default:
+          name_preheating_valve = "Unknown";
+          break;
+        }
+        preheating_valve->publish_state(name_preheating_valve);
+      }
+
+      if (frost_protection_active != nullptr)
+      {
+        frost_protection_active->publish_state(msg_data[1] != 0);
+      }
+
+      if (preheating_active != nullptr && msg_data[2] <= 1)
+      {
+        preheating_active->publish_state(msg_data[2] == 1);
+      }
+
+      if (frost_protection_minutes != nullptr)
+      {
+        frost_protection_minutes->publish_state((msg_data[3] << 8) | msg_data[4]);
+      }
+
+      if (frost_protection_level != nullptr)
+      {
+        std::string name_frost_protection_level;
+        switch (msg_data[5])
+        {
+        case 0:
+          name_frost_protection_level = "GuaranteedProtection";
+          break;
+
+        case 1:
+          name_frost_protection_level = "HighProtection";
+          break;
+
         case 2:
-          get_sensor_data_();
+          name_frost_protection_level = "NominalProtection";
           break;
+
         case 3:
-          get_ventilation_level_();
+          name_frost_protection_level = "Economy";
           break;
-        case 4:
-          get_temperatures_();
-          break;
-        case 5:
-          get_error_status_();
-          break;
-        case 6:
-          get_bypass_control_status_();
-          break;
-        case 7:
-          get_operation_hours_();
-          break;
-        case 8:
-          get_preheating_status_();
-          break;
-        case 9:
-          get_time_delay_();
+
+        default:
+          name_frost_protection_level = "Unknown";
           break;
         }
-
-        update_counter_++;
-        if (update_counter_ > num_update_counter_elements_)
-          update_counter_ = 0;
+        frost_protection_level->publish_state(name_frost_protection_level);
       }
-
-      void loop() override
-      {
-        while (available() != 0)
-        {
-          read_byte(&data_[data_index_]);
-          auto check = check_byte_();
-          if (!check.has_value())
-          {
-
-            // finished
-            if (data_[COMMAND_ID_ACK] != COMMAND_ACK)
-            {
-              parse_data_();
-            }
-            data_index_ = 0;
-          }
-          else if (!*check)
-          {
-            // wrong data
-            ESP_LOGV(TAG, "Byte %i of received data frame is invalid.", data_index_);
-            data_index_ = 0;
-          }
-          else
-          {
-            // next byte
-            data_index_++;
-          }
-        }
-      }
-
-      float get_setup_priority() const override { return setup_priority::DATA; }
-
-      void error_reset(void)
-      {
-        uint8_t reset_cmd[4] = {1, 0, 0, 0};
-        write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
-      }
-
-      void filter_reset(void)
-      {
-        uint8_t reset_cmd[4] = {0, 0, 0, 1};
-        write_command_(CMD_RESET_AND_SELF_TEST, reset_cmd, sizeof(reset_cmd));
-      }
-
-      void set_name(const char *value) { name = value; }
-      void set_name(const char *value, uint32_t name_hash)
-      {
-        (void)name_hash;
-        name = value;
-      }
-      void set_uart_component(uart::UARTComponent *parent) { set_uart_parent(parent); }
-      bool set_unit_size(uint8_t raw_size);
-      void set_size_select(ComfoAirSizeSelect *size_select);
-
-    protected:
-      void set_level_(int level)
-      {
-        if (level < 0 || level > 5)
-        {
-          ESP_LOGI(TAG, "Ignoring invalid level request: %i", level);
-          return;
-        }
-
-        ESP_LOGI(TAG, "Setting level to: %i", level);
-        {
-          uint8_t command[1] = {(uint8_t)level};
-          write_command_(CMD_SET_LEVEL, command, sizeof(command));
-        }
-      }
-
-      void set_comfort_temperature_(float temperature)
-      {
-        if (temperature < 12.0f || temperature > 29.0f)
-        {
-          ESP_LOGI(TAG, "Ignoring invalid temperature request: %i", temperature);
-          return;
-        }
-
-        ESP_LOGI(TAG, "Setting temperature to: %i", temperature);
-        {
-          uint8_t command[1] = {(uint8_t)((temperature + 20.0f) * 2.0f)};
-          write_command_(CMD_SET_COMFORT_TEMPERATURE, command, sizeof(command));
-        }
-      }
-
-      void set_fan_percentages()
-      {
-        // Ensure all numbers are linked before proceeding
-        if (!return_air_level_absent || !return_air_level_low || !return_air_level_medium || !return_air_level_high ||
-            !supply_air_level_absent || !supply_air_level_low || !supply_air_level_medium || !supply_air_level_high) {
-            ESP_LOGW("comfoair", "Cannot sync: One or more fan level entities are missing.");
-            return;
-        }
-
-        uint8_t data[9];
-        // Map states to bytes according to 0xCF specification
-        // std::clamp provides a final hardware safety check
-        data[0] = (uint8_t)std::clamp((int)return_air_level_absent->state, 15, 95);
-        data[1] = (uint8_t)std::clamp((int)return_air_level_low->state, 15, 95);
-        data[2] = (uint8_t)std::clamp((int)return_air_level_medium->state, 15, 95);
-        data[3] = (uint8_t)std::clamp((int)supply_air_level_absent->state, 15, 95);
-        data[4] = (uint8_t)std::clamp((int)supply_air_level_low->state, 15, 95);
-        data[5] = (uint8_t)std::clamp((int)supply_air_level_medium->state, 15, 95);
-        data[6] = (uint8_t)std::clamp((int)return_air_level_high->state, 15, 95);
-        data[7] = (uint8_t)std::clamp((int)supply_air_level_high->state, 15, 95);
-        data[8] = 0x00; // Reserved/Padding
-
-        ESP_LOGD("comfoair", "Sending 0xCF: Setting fan speed percentages.");
-        write_command_(CMD_SET_VENTILATION_LEVEL, data, sizeof(data));
-      }
-
-      void write_command_(const uint8_t command, const uint8_t *command_data, uint8_t command_data_length)
-      {
-        write_byte(COMMAND_PREFIX);
-        write_byte(COMMAND_HEAD);
-        write_byte(0x00);
-
-        uint16_t checksum = 173;
-        checksum += command;
-        checksum += command_data_length;
-
-        write_escaped_byte_(command);
-        write_escaped_byte_(command_data_length);
-
-        for (uint8_t i = 0; i < command_data_length; i++)
-        {
-          uint8_t data_byte = command_data[i];
-          checksum += data_byte;
-          write_escaped_byte_(data_byte);
-        }
-
-        uint8_t checksum_byte = static_cast<uint8_t>(checksum & 0xFF);
-        write_escaped_byte_(checksum_byte);
-
-        write_byte(COMMAND_PREFIX);
-        write_byte(COMMAND_TAIL);
-        flush();
-      }
-
-      void write_escaped_byte_(uint8_t value)
-      {
-        write_byte(value);
-        if (value == COMMAND_PREFIX)
-        {
-          write_byte(value);
-        }
-      }
-
-      uint8_t comfoair_checksum_(uint8_t command, uint8_t length, const uint8_t *command_data) const
-      {
-        uint16_t sum = 173;
-        sum += command;
-        sum += length;
-        if (command_data != nullptr)
-        {
-          for (uint8_t i = 0; i < length; i++)
-          {
-            sum += command_data[i];
-          }
-        }
-        return static_cast<uint8_t>(sum & 0xFF);
-      }
-
-      optional<bool> check_byte_() const
-      {
-        uint8_t index = data_index_;
-        uint8_t byte = data_[index];
-
-        if (index == 0)
-        {
-          return byte == COMMAND_PREFIX;
-        }
-
-        if (index == 1)
-        {
-          if (byte == COMMAND_ACK)
-          {
-            return {};
-          }
-          else
-          {
-            return byte == COMMAND_HEAD;
-          }
-        }
-
-        if (index == 2)
-        {
-          return byte == 0x00;
-        }
-
-        if (index < COMMAND_LEN_HEAD)
-        {
-          return true;
-        }
-
-        uint8_t data_length = data_[COMMAND_IDX_DATA];
-
-        if ((COMMAND_LEN_HEAD + data_length + COMMAND_LEN_TAIL) > sizeof(data_))
-        {
-          ESP_LOGW(TAG, "ComfoAir message too large");
-          return false;
-        }
-
-        if (index < COMMAND_LEN_HEAD + data_length)
-        {
-          return true;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length)
-        {
-          // checksum is without checksum bytes
-          uint8_t checksum = comfoair_checksum_(
-              data_[COMMAND_IDX_MSG_ID], data_length, data_ + COMMAND_LEN_HEAD);
-          if (checksum != byte)
-          {
-            // ESP_LOGW(TAG, "%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X", data_[0], data_[1], data_[2], data_[3], data_[4], data_[5], data_[6], data_[7], data_[8], data_[9], data_[10]);
-            ESP_LOGW(TAG, "ComfoAir Checksum doesn't match: 0x%02X!=0x%02X", byte, checksum);
-            return false;
-          }
-          return true;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length + 1)
-        {
-          return byte == COMMAND_PREFIX;
-        }
-
-        if (index == COMMAND_LEN_HEAD + data_length + 2)
-        {
-          if (byte != COMMAND_TAIL)
-          {
-            return false;
-          }
-        }
-
-        return {};
-      }
-
-      void parse_data_()
-      {
-        status_clear_warning();
-        uint8_t *msg = &data_[COMMAND_LEN_HEAD];
-
-        switch (data_[COMMAND_IDX_MSG_ID])
-        {
-        case RES_GET_BOOTLOADER_VERSION:
-          memcpy(bootloader_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_FIRMWARE_VERSION:
-          memcpy(firmware_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_CONNECTOR_BOARD_VERSION:
-          memcpy(connector_board_version_, msg, data_[COMMAND_IDX_DATA]);
-          break;
-        case RES_GET_FAN_STATUS:
-        {
-          if (intake_fan_speed != nullptr)
-          {
-            intake_fan_speed->publish_state(msg[0]);
-          }
-          if (exhaust_fan_speed != nullptr)
-          {
-            exhaust_fan_speed->publish_state(msg[1]);
-          }
-          if (intake_fan_speed_rpm != nullptr)
-          {
-            intake_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / get_uint16_(2)));
-          }
-          if (exhaust_fan_speed_rpm != nullptr)
-          {
-            exhaust_fan_speed_rpm->publish_state(static_cast<int>(1875000.0f / get_uint16_(4)));
-          }
-          break;
-        }
-        case RES_GET_VALVE_STATUS:
-        {
-          if (bypass_valve != nullptr)
-          {
-            bypass_valve->publish_state(msg[0]);
-          }
-          if (bypass_valve_open != nullptr)
-          {
-            bypass_valve_open->publish_state(msg[0] != 0);
-          }
-          // Value 2 means unknown; do not publish it as a false closed state.
-          if (preheating_state != nullptr && msg[1] <= 1)
-          {
-            preheating_state->publish_state(msg[1] == 1);
-          }
-          if (motor_current_bypass != nullptr)
-          {
-            motor_current_bypass->publish_state(msg[2]);
-          }
-          if (motor_current_preheating != nullptr)
-          {
-            motor_current_preheating->publish_state(msg[3]);
-          }
-          break;
-        }
-        case RES_GET_BYPASS_CONTROL_STATUS:
-        {
-          if (bypass_factor != nullptr)
-          {
-            bypass_factor->publish_state(msg[2]);
-          }
-          if (bypass_step != nullptr)
-          {
-            bypass_step->publish_state(msg[3]);
-          }
-          if (bypass_correction != nullptr)
-          {
-            bypass_correction->publish_state(msg[4]);
-          }
-          if (summer_mode != nullptr)
-          {
-            summer_mode->publish_state(msg[6] != 0);
-          }
-          break;
-        }
-        case RES_GET_TEMPERATURE_STATUS:
-        {
-
-          // T1 / outside air
-          if (outside_air_temperature != nullptr)
-          {
-            outside_air_temperature->publish_state((float)msg[0] / 2.0f - 20.0f);
-          }
-          // T2 / supply air
-          if (supply_air_temperature != nullptr)
-          {
-            supply_air_temperature->publish_state((float)msg[1] / 2.0f - 20.0f);
-          }
-          // T3 / return air
-          if (return_air_temperature != nullptr)
-          {
-            return_air_temperature->publish_state((float)msg[2] / 2.0f - 20.0f);
-          }
-          // T4 / exhaust air
-          if (exhaust_air_temperature != nullptr)
-          {
-            exhaust_air_temperature->publish_state((float)msg[3] / 2.0f - 20.0f);
-          }
-          break;
-        }
-        case RES_GET_SENSOR_DATA:
-        {
-
-          if (enthalpy_temperature != nullptr)
-          {
-            enthalpy_temperature->publish_state((float)msg[0] / 2.0f - 20.0f);
-          }
-
-          break;
-        }
-        case RES_GET_VENTILATION_LEVEL:
-        {
-
-          ESP_LOGD(TAG, "Level %02x", msg[8]);
-
-          if (return_air_level != nullptr)
-          {
-            return_air_level->publish_state(msg[6]);
-          }
-          if (supply_air_level != nullptr)
-          {
-            supply_air_level->publish_state(msg[7]);
-          }
-
-          if (ventilation_level != nullptr)
-          {
-            ventilation_level->publish_state(msg[8] - 1);
-          }
-
-          // Fan Speed
-          switch (msg[8])
-          {
-          case 0x00:
-            fan_mode.reset();
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          case 0x01:
-            fan_mode = climate::CLIMATE_FAN_OFF;
-            mode = climate::CLIMATE_MODE_OFF;
-            break;
-          case 0x02:
-            fan_mode = climate::CLIMATE_FAN_LOW;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          case 0x03:
-            fan_mode = climate::CLIMATE_FAN_MEDIUM;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          case 0x04:
-            fan_mode = climate::CLIMATE_FAN_HIGH;
-            mode = climate::CLIMATE_MODE_FAN_ONLY;
-            break;
-          }
-
-          // Update Return Air (Exhaust) Numbers
-          if (return_air_level_absent != nullptr) return_air_level_absent->publish_state(msg[0]);
-          if (return_air_level_low != nullptr)    return_air_level_low->publish_state(msg[1]);
-          if (return_air_level_medium != nullptr) return_air_level_medium->publish_state(msg[2]);
-          if (return_air_level_high != nullptr)   return_air_level_high->publish_state(msg[10]);
-
-          // Update Supply Air Numbers
-          if (supply_air_level_absent != nullptr) supply_air_level_absent->publish_state(msg[3]);
-          if (supply_air_level_low != nullptr)    supply_air_level_low->publish_state(msg[4]);
-          if (supply_air_level_medium != nullptr) supply_air_level_medium->publish_state(msg[5]);
-          if (supply_air_level_high != nullptr)   supply_air_level_high->publish_state(msg[11]);
-
-          publish_state();
-
-          // Supply air fan active (1 = active / 0 = inactive)
-          if (supply_fan_active != nullptr)
-          {
-            supply_fan_active->publish_state(msg[9] == 1);
-          }
-          break;
-        }
-        case RES_GET_FAULTS:
-        {
-          const uint8_t status = msg[8];
-          if (filter_status != nullptr)
-          {
-            filter_status->publish_state(status == 0 ? "Ok" : (status == 1 ? "Full" : "Unknown"));
-          }
-          // Keep the binary sensor unknown when the protocol does not report a valid OK/full value.
-          if (filter_status_full != nullptr && status <= 1)
-          {
-            filter_status_full->publish_state(status == 1);
-          }
-          break;
-        }
-        case RES_GET_TEMPERATURES:
-        {
-
-          // comfort temperature
-          target_temperature = (float)msg[0] / 2.0f - 20.0f;
-          publish_state();
-
-          // T1 / outside air
-          if (outside_air_temperature != nullptr && msg[5] & 0x01)
-          {
-            outside_air_temperature->publish_state((float)msg[1] / 2.0f - 20.0f);
-          }
-          // T2 / supply air
-          if (supply_air_temperature != nullptr && msg[5] & 0x02)
-          {
-            supply_air_temperature->publish_state((float)msg[2] / 2.0f - 20.0f);
-          }
-          // T3 / exhaust air
-          if (return_air_temperature != nullptr && msg[5] & 0x04)
-          {
-            return_air_temperature->publish_state((float)msg[3] / 2.0f - 20.0f);
-            current_temperature = (float)msg[3] / 2.0f - 20.0f;
-          }
-          // T4 / continued air
-          if (exhaust_air_temperature != nullptr && msg[5] & 0x08)
-          {
-            exhaust_air_temperature->publish_state((float)msg[4] / 2.0f - 20.0f);
-          }
-          // EWT
-          if (ewt_temperature != nullptr && msg[5] & 0x10)
-          {
-            ewt_temperature->publish_state((float)msg[6] / 2.0f - 20.0f);
-          }
-          // reheating
-          if (reheating_temperature != nullptr && msg[5] & 0x20)
-          {
-            reheating_temperature->publish_state((float)msg[7] / 2.0f - 20.0f);
-          }
-          // kitchen hood
-          if (kitchen_hood_temperature != nullptr && msg[5] & 0x40)
-          {
-            kitchen_hood_temperature->publish_state((float)msg[8] / 2.0f - 20.0f);
-          }
-
-          break;
-        }
-        case RES_GET_STATUS:
-        {
-          if (preheating_present != nullptr)
-          {
-            preheating_present->publish_state(msg[0]);
-          }
-
-          if (bypass_present != nullptr)
-          {
-            bypass_present->publish_state(msg[1]);
-          }
-
-          if (type != nullptr)
-          {
-            type->publish_state(msg[2] == 1 ? "Left" : (msg[2] == 2 ? "Right" : "Unknown"));
-          }
-
-          publish_size_entities_(msg[3]);
-
-          if (options_present != nullptr)
-          {
-            options_present->publish_state(msg[4]);
-          }
-
-          if (fireplace_present != nullptr)
-          {
-            fireplace_present->publish_state(msg[4] & 0x01);
-          }
-
-          if (kitchen_hood_present != nullptr)
-          {
-            kitchen_hood_present->publish_state(msg[4] & 0x02);
-          }
-
-          if (postheating_present != nullptr)
-          {
-            postheating_present->publish_state(msg[4] & 0x04);
-          }
-
-          if (postheating_pwm_mode_present != nullptr)
-          {
-            postheating_pwm_mode_present->publish_state(msg[4] & 0x40);
-          }
-
-          if (p10_active != nullptr)
-          {
-            p10_active->publish_state(msg[6] & 0x01);
-          }
-
-          if (p11_active != nullptr)
-          {
-            p11_active->publish_state(msg[6] & 0x02);
-          }
-
-          if (p12_active != nullptr)
-          {
-            p12_active->publish_state(msg[6] & 0x04);
-          }
-
-          if (p13_active != nullptr)
-          {
-            p13_active->publish_state(msg[6] & 0x08);
-          }
-
-          if (p14_active != nullptr)
-          {
-            p14_active->publish_state(msg[6] & 0x10);
-          }
-
-          if (p15_active != nullptr)
-          {
-            p15_active->publish_state(msg[6] & 0x20);
-          }
-
-          if (p16_active != nullptr)
-          {
-            p16_active->publish_state(msg[6] & 0x40);
-          }
-
-          if (p17_active != nullptr)
-          {
-            p17_active->publish_state(msg[6] & 0x80);
-          }
-
-          if (p18_active != nullptr)
-          {
-            p18_active->publish_state(msg[7] & 0x01);
-          }
-
-          if (p19_active != nullptr)
-          {
-            p19_active->publish_state(msg[7] & 0x02);
-          }
-
-          if (p90_active != nullptr)
-          {
-            p90_active->publish_state(msg[8] & 0x01);
-          }
-
-          if (p91_active != nullptr)
-          {
-            p91_active->publish_state(msg[8] & 0x02);
-          }
-
-          if (p92_active != nullptr)
-          {
-            p92_active->publish_state(msg[8] & 0x04);
-          }
-
-          if (p93_active != nullptr)
-          {
-            p93_active->publish_state(msg[8] & 0x08);
-          }
-
-          if (p94_active != nullptr)
-          {
-            p94_active->publish_state(msg[8] & 0x10);
-          }
-
-          if (p95_active != nullptr)
-          {
-            p95_active->publish_state(msg[8] & 0x20);
-          }
-
-          if (p96_active != nullptr)
-          {
-            p96_active->publish_state(msg[8] & 0x40);
-          }
-
-          if (p97_active != nullptr)
-          {
-            p97_active->publish_state(msg[8] & 0x80);
-          }
-
-          if (enthalpy_present != nullptr)
-          {
-            enthalpy_present->publish_state(msg[9]);
-          }
-
-          if (ewt_present != nullptr)
-          {
-            ewt_present->publish_state(msg[10]);
-          }
-
-          if (data_[COMMAND_IDX_DATA] >= 11)
-          {
-            status_payload_[0] = msg[0];
-            status_payload_[1] = msg[1];
-            status_payload_[2] = msg[2];
-            status_payload_[3] = msg[3];
-            status_payload_[4] = msg[4];
-            status_payload_[5] = msg[5];
-            status_payload_[6] = msg[9];
-            status_payload_[7] = msg[10];
-            status_payload_valid_ = true;
-          }
-          else
-          {
-            status_payload_valid_ = false;
-          }
-          break;
-        }
-        case RES_GET_OPERATION_HOURS:
-        {
-          if (level0_hours != nullptr)
-          {
-            level0_hours->publish_state((msg[0] << 16) | (msg[1] << 8) | msg[2]);
-          }
-
-          if (level1_hours != nullptr)
-          {
-            level1_hours->publish_state((msg[3] << 16) | (msg[4] << 8) | msg[5]);
-          }
-
-          if (level2_hours != nullptr)
-          {
-            level2_hours->publish_state((msg[6] << 16) | (msg[7] << 8) | msg[8]);
-          }
-
-          if (level3_hours != nullptr)
-          {
-            level3_hours->publish_state((msg[17] << 16) | (msg[18] << 8) | msg[19]);
-          }
-
-          if (frost_protection_hours != nullptr)
-          {
-            frost_protection_hours->publish_state((msg[9] << 8) | msg[10]);
-          }
-
-          if (bypass_open_hours != nullptr)
-          {
-            bypass_open_hours->publish_state((msg[13] << 8) | msg[14]);
-          }
-
-          if (preheating_hours != nullptr)
-          {
-            preheating_hours->publish_state((msg[11] << 8) | msg[12]);
-          }
-
-          if (filter_hours != nullptr)
-          {
-            filter_hours->publish_state((msg[15] << 8) | msg[16]);
-          }
-          break;
-        }
-
-        case RES_GET_PREHEATING_STATUS:
-        {
-          if (preheating_valve != nullptr)
-          {
-            std::string name_preheating_valve;
-            switch (msg[0])
-            {
-            case 0:
-              name_preheating_valve = "Closed";
-              break;
-
-            case 1:
-              name_preheating_valve = "Open";
-              break;
-
-            default:
-              name_preheating_valve = "Unknown";
-              break;
-            }
-            preheating_valve->publish_state(name_preheating_valve);
-          }
-
-          if (frost_protection_active != nullptr)
-          {
-            frost_protection_active->publish_state(msg[1] != 0);
-          }
-
-          if (preheating_active != nullptr && msg[2] <= 1)
-          {
-            preheating_active->publish_state(msg[2] == 1);
-          }
-
-          if (frost_protection_minutes != nullptr)
-          {
-            frost_protection_minutes->publish_state((msg[3] << 8) | msg[4]);
-          }
-
-          if (frost_protection_level != nullptr)
-          {
-            std::string name_frost_protection_level;
-            switch (msg[5])
-            {
-            case 0:
-              name_frost_protection_level = "GuaranteedProtection";
-              break;
-
-            case 1:
-              name_frost_protection_level = "HighProtection";
-              break;
-
-            case 2:
-              name_frost_protection_level = "NominalProtection";
-              break;
-
-            case 3:
-              name_frost_protection_level = "Economy";
-              break;
-
-            default:
-              name_frost_protection_level = "Unknown";
-              break;
-            }
-            frost_protection_level->publish_state(name_frost_protection_level);
-          }
-          break;
-        }
-        case RES_GET_TIME_DELAY:
-        {
-          if (bathroom_switch_on_delay_minutes != nullptr)
-          {
-            bathroom_switch_on_delay_minutes->publish_state(msg[0]);
-          }
-
-          if (bathroom_switch_off_delay_minutes != nullptr)
-          {
-            bathroom_switch_off_delay_minutes->publish_state(msg[1]);
-          }
-
-          if (l1_switch_off_delay_minutes != nullptr)
-          {
-            l1_switch_off_delay_minutes->publish_state(msg[2]);
-          }
-
-          if (boost_ventilation_minutes != nullptr)
-          {
-            boost_ventilation_minutes->publish_state(msg[3]);
-          }
-
-          if (filter_warning_weeks != nullptr)
-          {
-            filter_warning_weeks->publish_state(msg[4]);
-          }
-
-          if (rf_high_time_short_minutes != nullptr)
-          {
-            rf_high_time_short_minutes->publish_state(msg[5]);
-          }
-
-          if (rf_high_time_long_minutes != nullptr)
-          {
-            rf_high_time_long_minutes->publish_state(msg[6]);
-          }
-
-          if (extractor_hood_switch_off_delay_minutes != nullptr)
-          {
-            extractor_hood_switch_off_delay_minutes->publish_state(msg[7]);
-          }
-
-          break;
-        }
-        }
-      }
-
-      void get_fan_status_()
-      {
-        if (intake_fan_speed != nullptr ||
-            exhaust_fan_speed != nullptr ||
-            intake_fan_speed_rpm != nullptr ||
-            exhaust_fan_speed_rpm != nullptr)
-        {
-          ESP_LOGD(TAG, "getting fan status");
-          write_command_(CMD_GET_FAN_STATUS, nullptr, 0);
-        }
-      }
-
-      void get_valve_status_()
-      {
-        if (bypass_valve != nullptr ||
-            bypass_valve_open != nullptr ||
-            preheating_state != nullptr)
-        {
-          ESP_LOGD(TAG, "getting valve status");
-          write_command_(CMD_GET_VALVE_STATUS, nullptr, 0);
-        }
-      }
-
-      void get_error_status_()
-      {
-        if (filter_status != nullptr ||
-            filter_status_full != nullptr)
-        {
-          ESP_LOGD(TAG, "getting error status");
-          write_command_(CMD_GET_FAULTS, nullptr, 0);
-        }
-      }
-
-      void get_bypass_control_status_()
-      {
-        if (bypass_factor != nullptr ||
-            bypass_step != nullptr ||
-            bypass_correction != nullptr ||
-            summer_mode != nullptr)
-        {
-          ESP_LOGD(TAG, "getting bypass control");
-          write_command_(CMD_GET_BYPASS_CONTROL_STATUS, nullptr, 0);
-        }
-      }
-
-      void get_temperature_()
-      {
-        if (outside_air_temperature != nullptr ||
-            supply_air_temperature != nullptr ||
-            return_air_temperature != nullptr ||
-            outside_air_temperature != nullptr)
-        {
-          ESP_LOGD(TAG, "getting temperature");
-          write_command_(CMD_GET_TEMPERATURE_STATUS, nullptr, 0);
-        }
-      }
-
-      void get_sensor_data_()
-      {
-        if (enthalpy_temperature != nullptr)
-        {
-          ESP_LOGD(TAG, "getting sensor data");
-          write_command_(CMD_GET_SENSOR_DATA, nullptr, 0);
-        }
-      }
-
-      void get_ventilation_level_()
-      {
-        ESP_LOGD(TAG, "getting ventilation level");
-        write_command_(CMD_GET_VENTILATION_LEVEL, nullptr, 0);
-      }
-
-      void get_temperatures_()
-      {
-        ESP_LOGD(TAG, "getting temperatures");
-        write_command_(CMD_GET_TEMPERATURES, nullptr, 0);
-      }
-
-      void get_operation_hours_()
-      {
-        ESP_LOGD(TAG, "getting operation hours");
-        write_command_(CMD_GET_OPERATION_HOURS, nullptr, 0);
-      }
-
-      void get_preheating_status_()
-      {
-        ESP_LOGD(TAG, "getting preheating status");
-        write_command_(CMD_GET_PREHEATING_STATUS, nullptr, 0);
-      }
-
-      void get_time_delay_()
-      {
-        ESP_LOGD(TAG, "getting time delay");
-        write_command_(CMD_GET_TIME_DELAY, nullptr, 0);
-      }
-
-      uint8_t get_uint8_t_(uint8_t start_index) const
-      {
-        return data_[COMMAND_LEN_HEAD + start_index];
-      }
-
-      uint16_t get_uint16_(uint8_t start_index) const
-      {
-        return (uint16_t(data_[COMMAND_LEN_HEAD + start_index + 1] | data_[COMMAND_LEN_HEAD + start_index] << 8));
-      }
-
-      void publish_size_entities_(uint8_t raw_size);
-      const char *unit_size_text_label_(uint8_t raw_size) const;
-      const char *unit_size_option_label_(uint8_t raw_size) const;
-
-      uint8_t data_[30];
-      uint8_t data_index_{0};
-      int8_t update_counter_{-4};
-      const int8_t num_update_counter_elements_{9};
-      uint8_t status_payload_[8]{0};
-      bool status_payload_valid_{false};
-      uint8_t current_unit_size_{0};
-      ComfoAirSizeSelect *size_select_{nullptr};
-
-      uint8_t bootloader_version_[13]{0};
-      uint8_t firmware_version_[13]{0};
-      uint8_t connector_board_version_[14]{0};
-      const char *name{0};
-
-    public:
-      text_sensor::TextSensor *type{nullptr};
-      text_sensor::TextSensor *size{nullptr};
-      text_sensor::TextSensor *filter_status{nullptr};
-      binary_sensor::BinarySensor *filter_status_full{nullptr};
-      text_sensor::TextSensor *frost_protection_level{nullptr};
-      text_sensor::TextSensor *preheating_valve{nullptr};
-      sensor::Sensor *intake_fan_speed{nullptr};
-      sensor::Sensor *exhaust_fan_speed{nullptr};
-      sensor::Sensor *intake_fan_speed_rpm{nullptr};
-      sensor::Sensor *exhaust_fan_speed_rpm{nullptr};
-      sensor::Sensor *ventilation_level{nullptr};
-      sensor::Sensor *outside_air_temperature{nullptr};
-      sensor::Sensor *supply_air_temperature{nullptr};
-      sensor::Sensor *return_air_temperature{nullptr};
-      sensor::Sensor *exhaust_air_temperature{nullptr};
-      sensor::Sensor *enthalpy_temperature{nullptr};
-      sensor::Sensor *ewt_temperature{nullptr};
-      sensor::Sensor *reheating_temperature{nullptr};
-      sensor::Sensor *kitchen_hood_temperature{nullptr};
-      sensor::Sensor *return_air_level{nullptr};
-      sensor::Sensor *supply_air_level{nullptr};
-      sensor::Sensor *bypass_factor{nullptr};
-      sensor::Sensor *bypass_step{nullptr};
-      sensor::Sensor *bypass_correction{nullptr};
-      sensor::Sensor *bypass_open_hours{nullptr};
-      sensor::Sensor *motor_current_bypass{nullptr};
-      sensor::Sensor *motor_current_preheating{nullptr};
-      sensor::Sensor *preheating_hours{nullptr};
-      sensor::Sensor *level0_hours{nullptr};
-      sensor::Sensor *level1_hours{nullptr};
-      sensor::Sensor *level2_hours{nullptr};
-      sensor::Sensor *level3_hours{nullptr};
-      binary_sensor::BinarySensor *frost_protection_active{nullptr};
-      sensor::Sensor *frost_protection_hours{nullptr};
-      sensor::Sensor *frost_protection_minutes{nullptr};
-      sensor::Sensor *filter_hours{nullptr};
-      sensor::Sensor *bypass_valve{nullptr};
-      binary_sensor::BinarySensor *bypass_present{nullptr};
-      binary_sensor::BinarySensor *enthalpy_present{nullptr};
-      binary_sensor::BinarySensor *ewt_present{nullptr};
-      binary_sensor::BinarySensor *preheating_present{nullptr};
-      binary_sensor::BinarySensor *options_present{nullptr};
-      binary_sensor::BinarySensor *fireplace_present{nullptr};
-      binary_sensor::BinarySensor *kitchen_hood_present{nullptr};
-      binary_sensor::BinarySensor *postheating_present{nullptr};
-      binary_sensor::BinarySensor *postheating_pwm_mode_present{nullptr};
-      binary_sensor::BinarySensor *bypass_valve_open{nullptr};
-      binary_sensor::BinarySensor *preheating_state{nullptr};
-      binary_sensor::BinarySensor *preheating_active{nullptr};
-      binary_sensor::BinarySensor *summer_mode{nullptr};
-      binary_sensor::BinarySensor *supply_fan_active{nullptr};
-      binary_sensor::BinarySensor *p10_active{nullptr};
-      binary_sensor::BinarySensor *p11_active{nullptr};
-      binary_sensor::BinarySensor *p12_active{nullptr};
-      binary_sensor::BinarySensor *p13_active{nullptr};
-      binary_sensor::BinarySensor *p14_active{nullptr};
-      binary_sensor::BinarySensor *p15_active{nullptr};
-      binary_sensor::BinarySensor *p16_active{nullptr};
-      binary_sensor::BinarySensor *p17_active{nullptr};
-      binary_sensor::BinarySensor *p18_active{nullptr};
-      binary_sensor::BinarySensor *p19_active{nullptr};
-      binary_sensor::BinarySensor *p90_active{nullptr};
-      binary_sensor::BinarySensor *p91_active{nullptr};
-      binary_sensor::BinarySensor *p92_active{nullptr};
-      binary_sensor::BinarySensor *p93_active{nullptr};
-      binary_sensor::BinarySensor *p94_active{nullptr};
-      binary_sensor::BinarySensor *p95_active{nullptr};
-      binary_sensor::BinarySensor *p96_active{nullptr};
-      binary_sensor::BinarySensor *p97_active{nullptr};
-      sensor::Sensor *bathroom_switch_on_delay_minutes{nullptr};
-      sensor::Sensor *bathroom_switch_off_delay_minutes{nullptr};
-      sensor::Sensor *l1_switch_off_delay_minutes{nullptr};
-      sensor::Sensor *boost_ventilation_minutes{nullptr};
-      sensor::Sensor *filter_warning_weeks{nullptr};
-      sensor::Sensor *rf_high_time_short_minutes{nullptr};
-      sensor::Sensor *rf_high_time_long_minutes{nullptr};
-      sensor::Sensor *extractor_hood_switch_off_delay_minutes{nullptr};
-      ComfoAirNumber *return_air_level_absent{nullptr};
-      ComfoAirNumber *return_air_level_low{nullptr};
-      ComfoAirNumber *return_air_level_medium{nullptr};
-      ComfoAirNumber *return_air_level_high{nullptr};
-      ComfoAirNumber *supply_air_level_absent{nullptr};
-      ComfoAirNumber *supply_air_level_low{nullptr};
-      ComfoAirNumber *supply_air_level_medium{nullptr};
-      ComfoAirNumber *supply_air_level_high{nullptr};
-      ComfoAirSyncButton *sync_button_{nullptr};
-
-      void set_type(text_sensor::TextSensor *type) { this->type = type; };
-      void set_size(text_sensor::TextSensor *size) { this->size = size; };
-      void set_intake_fan_speed(sensor::Sensor *intake_fan_speed) { this->intake_fan_speed = intake_fan_speed; };
-      void set_exhaust_fan_speed(sensor::Sensor *exhaust_fan_speed) { this->exhaust_fan_speed = exhaust_fan_speed; };
-      void set_intake_fan_speed_rpm(sensor::Sensor *intake_fan_speed_rpm)
-      {
-        this->intake_fan_speed_rpm = intake_fan_speed_rpm;
-        this->intake_fan_speed_rpm->set_accuracy_decimals(0);
-      };
-      void set_exhaust_fan_speed_rpm(sensor::Sensor *exhaust_fan_speed_rpm)
-      {
-        this->exhaust_fan_speed_rpm = exhaust_fan_speed_rpm;
-        this->exhaust_fan_speed_rpm->set_accuracy_decimals(0);
-      };
-      void set_ventilation_level(sensor::Sensor *ventilation_level) { this->ventilation_level = ventilation_level; };
-      void set_bypass_valve(sensor::Sensor *bypass_valve) { this->bypass_valve = bypass_valve; };
-      void set_bypass_present(binary_sensor::BinarySensor *bypass_present) { this->bypass_present = bypass_present; };
-      void set_enthalpy_present(binary_sensor::BinarySensor *enthalpy_present) { this->enthalpy_present = enthalpy_present; };
-      void set_ewt_present(binary_sensor::BinarySensor *ewt_present) { this->ewt_present = ewt_present; };
-      void set_preheating_present(binary_sensor::BinarySensor *preheating_present) { this->preheating_present = preheating_present; };
-      void set_options_present(binary_sensor::BinarySensor *options_present) { this->options_present = options_present; };
-      void set_fireplace_present(binary_sensor::BinarySensor *fireplace_present) { this->fireplace_present = fireplace_present; };
-      void set_kitchen_hood_present(binary_sensor::BinarySensor *kitchen_hood_present) { this->kitchen_hood_present = kitchen_hood_present; };
-      void set_postheating_present(binary_sensor::BinarySensor *postheating_present) { this->postheating_present = postheating_present; };
-      void set_postheating_pwm_mode_present(binary_sensor::BinarySensor *postheating_pwm_mode_present) { this->postheating_pwm_mode_present = postheating_pwm_mode_present; };
-      void set_bypass_valve_open(binary_sensor::BinarySensor *bypass_valve_open) { this->bypass_valve_open = bypass_valve_open; };
-      void set_preheating_state(binary_sensor::BinarySensor *preheating_state) { this->preheating_state = preheating_state; };
-      void set_preheating_active(binary_sensor::BinarySensor *preheating_active) { this->preheating_active = preheating_active; };
-      void set_outside_air_temperature(sensor::Sensor *outside_air_temperature) { this->outside_air_temperature = outside_air_temperature; };
-      void set_supply_air_temperature(sensor::Sensor *supply_air_temperature) { this->supply_air_temperature = supply_air_temperature; };
-      void set_return_air_temperature(sensor::Sensor *return_air_temperature) { this->return_air_temperature = return_air_temperature; };
-      void set_exhaust_air_temperature(sensor::Sensor *exhaust_air_temperature) { this->exhaust_air_temperature = exhaust_air_temperature; };
-      void set_enthalpy_temperature(sensor::Sensor *enthalpy_temperature) { this->enthalpy_temperature = enthalpy_temperature; };
-      void set_ewt_temperature(sensor::Sensor *ewt_temperature) { this->ewt_temperature = ewt_temperature; };
-      void set_reheating_temperature(sensor::Sensor *reheating_temperature) { this->reheating_temperature = reheating_temperature; };
-      void set_kitchen_hood_temperature(sensor::Sensor *kitchen_hood_temperature) { this->kitchen_hood_temperature = kitchen_hood_temperature; };
-      void set_return_air_level(sensor::Sensor *return_air_level) { this->return_air_level = return_air_level; };
-      void set_supply_air_level(sensor::Sensor *supply_air_level) { this->supply_air_level = supply_air_level; };
-      void set_supply_fan_active(binary_sensor::BinarySensor *supply_fan_active) { this->supply_fan_active = supply_fan_active; };
-      void set_filter_status(text_sensor::TextSensor *filter_status) { this->filter_status = filter_status; };
-      void set_filter_status_full(binary_sensor::BinarySensor *filter_status_full) { this->filter_status_full = filter_status_full; };
-      void set_bypass_factor(sensor::Sensor *bypass_factor) { this->bypass_factor = bypass_factor; };
-      void set_bypass_step(sensor::Sensor *bypass_step) { this->bypass_step = bypass_step; };
-      void set_bypass_correction(sensor::Sensor *bypass_correction) { this->bypass_correction = bypass_correction; };
-      void set_bypass_open_hours(sensor::Sensor *bypass_open_hours) { this->bypass_open_hours = bypass_open_hours; };
-      void set_motor_current_bypass(sensor::Sensor *motor_current_bypass) { this->motor_current_bypass = motor_current_bypass; };
-      void set_motor_current_preheating(sensor::Sensor *motor_current_preheating) { this->motor_current_preheating = motor_current_preheating; };
-      void set_preheating_hours(sensor::Sensor *preheating_hours) { this->preheating_hours = preheating_hours; };
-      void set_preheating_valve(text_sensor::TextSensor *preheating_valve) { this->preheating_valve = preheating_valve; };
-      void set_level0_hours(sensor::Sensor *level0_hours) { this->level0_hours = level0_hours; };
-      void set_level1_hours(sensor::Sensor *level1_hours) { this->level1_hours = level1_hours; };
-      void set_level2_hours(sensor::Sensor *level2_hours) { this->level2_hours = level2_hours; };
-      void set_level3_hours(sensor::Sensor *level3_hours) { this->level3_hours = level3_hours; };
-      void set_frost_protection_active(binary_sensor::BinarySensor *frost_protection_active) { this->frost_protection_active = frost_protection_active; };
-      void set_frost_protection_hours(sensor::Sensor *frost_protection_hours) { this->frost_protection_hours = frost_protection_hours; };
-      void set_frost_protection_minutes(sensor::Sensor *frost_protection_minutes) { this->frost_protection_minutes = frost_protection_minutes; };
-      void set_frost_protection_level(text_sensor::TextSensor *frost_protection_level) { this->frost_protection_level = frost_protection_level; };
-      void set_filter_hours(sensor::Sensor *filter_hours) { this->filter_hours = filter_hours; };
-      void set_summer_mode(binary_sensor::BinarySensor *summer_mode) { this->summer_mode = summer_mode; };
-      void set_p10_active(binary_sensor::BinarySensor *p10_active) { this->p10_active = p10_active; };
-      void set_p11_active(binary_sensor::BinarySensor *p11_active) { this->p11_active = p11_active; };
-      void set_p12_active(binary_sensor::BinarySensor *p12_active) { this->p12_active = p12_active; };
-      void set_p13_active(binary_sensor::BinarySensor *p13_active) { this->p13_active = p13_active; };
-      void set_p14_active(binary_sensor::BinarySensor *p14_active) { this->p14_active = p14_active; };
-      void set_p15_active(binary_sensor::BinarySensor *p15_active) { this->p15_active = p15_active; };
-      void set_p16_active(binary_sensor::BinarySensor *p16_active) { this->p16_active = p16_active; };
-      void set_p17_active(binary_sensor::BinarySensor *p17_active) { this->p17_active = p17_active; };
-      void set_p18_active(binary_sensor::BinarySensor *p18_active) { this->p18_active = p18_active; };
-      void set_p19_active(binary_sensor::BinarySensor *p19_active) { this->p19_active = p19_active; };
-      void set_p90_active(binary_sensor::BinarySensor *p90_active) { this->p90_active = p90_active; };
-      void set_p91_active(binary_sensor::BinarySensor *p91_active) { this->p91_active = p91_active; };
-      void set_p92_active(binary_sensor::BinarySensor *p92_active) { this->p92_active = p92_active; };
-      void set_p93_active(binary_sensor::BinarySensor *p93_active) { this->p93_active = p93_active; };
-      void set_p94_active(binary_sensor::BinarySensor *p94_active) { this->p94_active = p94_active; };
-      void set_p95_active(binary_sensor::BinarySensor *p95_active) { this->p95_active = p95_active; };
-      void set_p96_active(binary_sensor::BinarySensor *p96_active) { this->p96_active = p96_active; };
-      void set_p97_active(binary_sensor::BinarySensor *p97_active) { this->p97_active = p97_active; };
-      void set_bathroom_switch_on_delay_minutes(sensor::Sensor *bathroom_switch_on_delay_minutes) { this->bathroom_switch_on_delay_minutes = bathroom_switch_on_delay_minutes; };
-      void set_bathroom_switch_off_delay_minutes(sensor::Sensor *bathroom_switch_off_delay_minutes) { this->bathroom_switch_off_delay_minutes = bathroom_switch_off_delay_minutes; };
-      void set_l1_switch_off_delay_minutes(sensor::Sensor *l1_switch_off_delay_minutes) { this->l1_switch_off_delay_minutes = l1_switch_off_delay_minutes; };
-      void set_boost_ventilation_minutes(sensor::Sensor *boost_ventilation_minutes) { this->boost_ventilation_minutes = boost_ventilation_minutes; };
-      void set_filter_warning_weeks(sensor::Sensor *filter_warning_weeks) { this->filter_warning_weeks = filter_warning_weeks; };
-      void set_rf_high_time_short_minutes(sensor::Sensor *rf_high_time_short_minutes) { this->rf_high_time_short_minutes = rf_high_time_short_minutes; };
-      void set_rf_high_time_long_minutes(sensor::Sensor *rf_high_time_long_minutes) { this->rf_high_time_long_minutes = rf_high_time_long_minutes; };
-      void set_extractor_hood_switch_off_delay_minutes(sensor::Sensor *extractor_hood_switch_off_delay_minutes) { this->extractor_hood_switch_off_delay_minutes = extractor_hood_switch_off_delay_minutes; };
-      void set_return_air_level_absent(ComfoAirNumber *n)
-      {
-        this->return_air_level_absent = n;
-        if (this->return_air_level_absent != nullptr) {
-          this->return_air_level_absent->set_parent(this);
-        }
-      };
-      void set_return_air_level_low(ComfoAirNumber *n)
-      {
-        this->return_air_level_low = n;
-        if (this->return_air_level_low != nullptr) {
-          this->return_air_level_low->set_parent(this);
-        }
-      };
-      void set_return_air_level_medium(ComfoAirNumber *n)
-      {
-        this->return_air_level_medium = n;
-        if (this->return_air_level_medium != nullptr) {
-          this->return_air_level_medium->set_parent(this);
-        }
-      };
-      void set_return_air_level_high(ComfoAirNumber *n)
-      {
-        this->return_air_level_high = n;
-        if (this->return_air_level_high != nullptr) {
-          this->return_air_level_high->set_parent(this);
-        }
-      };
-      void set_supply_air_level_absent(ComfoAirNumber *n)
-      {
-        this->supply_air_level_absent = n;
-        if (this->supply_air_level_absent != nullptr) {
-          this->supply_air_level_absent->set_parent(this);
-        }
-      };
-      void set_supply_air_level_low(ComfoAirNumber *n)
-      {
-        this->supply_air_level_low = n;
-        if (this->supply_air_level_low != nullptr) {
-          this->supply_air_level_low->set_parent(this);
-        }
-      };
-      void set_supply_air_level_medium(ComfoAirNumber *n)
-      {
-        this->supply_air_level_medium = n;
-        if (this->supply_air_level_medium != nullptr) {
-          this->supply_air_level_medium->set_parent(this);
-        }
-      };
-      void set_supply_air_level_high(ComfoAirNumber *n)
-      {
-        this->supply_air_level_high = n;
-        if (this->supply_air_level_high != nullptr) {
-          this->supply_air_level_high->set_parent(this);
-        }
-      };
-      void set_sync_fan_levels(ComfoAirSyncButton *b)
-      {
-        this->sync_button_ = b;
-        if (this->sync_button_ != nullptr) {
-          this->sync_button_->set_parent(this);
-        }
-      }
-    };
-
-    inline const char *ComfoAirComponent::unit_size_text_label_(uint8_t raw_size) const
+      break;
+    }
+    case RES_GET_TIME_DELAY:
     {
-      switch (raw_size)
+      if (bathroom_switch_on_delay_minutes != nullptr)
       {
-      case 1:
-        return "Large";
-      case 2:
-        return "Small";
-      default:
-        return "Unknown";
+        bathroom_switch_on_delay_minutes->publish_state(msg_data[0]);
       }
-    }
 
-    inline const char *ComfoAirComponent::unit_size_option_label_(uint8_t raw_size) const
+      if (bathroom_switch_off_delay_minutes != nullptr)
+      {
+        bathroom_switch_off_delay_minutes->publish_state(msg_data[1]);
+      }
+
+      if (l1_switch_off_delay_minutes != nullptr)
+      {
+        l1_switch_off_delay_minutes->publish_state(msg_data[2]);
+      }
+
+      if (boost_ventilation_minutes != nullptr)
+      {
+        boost_ventilation_minutes->publish_state(msg_data[3]);
+      }
+
+      if (filter_warning_weeks != nullptr)
+      {
+        filter_warning_weeks->publish_state(msg_data[4]);
+      }
+
+      if (rf_high_time_short_minutes != nullptr)
+      {
+        rf_high_time_short_minutes->publish_state(msg_data[5]);
+      }
+
+      if (rf_high_time_long_minutes != nullptr)
+      {
+        rf_high_time_long_minutes->publish_state(msg_data[6]);
+      }
+
+      if (extractor_hood_switch_off_delay_minutes != nullptr)
+      {
+        extractor_hood_switch_off_delay_minutes->publish_state(msg_data[7]);
+      }
+      break;
+    }
+    }
+  }
+
+  // --- getter ---
+
+  void get_fan_status_()
+  {
+    if (intake_fan_speed != nullptr || exhaust_fan_speed != nullptr || intake_fan_speed_rpm != nullptr ||
+        exhaust_fan_speed_rpm != nullptr)
     {
-      switch (raw_size)
-      {
-      case 1:
-        return "Large";
-      case 2:
-        return "Small";
-      default:
-        return nullptr;
-      }
+      ESP_LOGD(TAG, "getting fan status");
+      write_command_(CMD_GET_FAN_STATUS, nullptr, 0);
     }
+  }
 
-    inline void ComfoAirComponent::publish_size_entities_(uint8_t raw_size)
+  void get_valve_status_()
+  {
+    if (bypass_valve != nullptr || bypass_valve_open != nullptr || preheating_state != nullptr)
     {
-      current_unit_size_ = raw_size;
-      if (size != nullptr)
-      {
-        size->publish_state(unit_size_text_label_(raw_size));
-      }
-      if (size_select_ != nullptr)
-      {
-        if (const char *option = unit_size_option_label_(raw_size))
-        {
-          size_select_->publish_state(option);
-        }
-        else
-        {
-          ESP_LOGW(TAG, "Unsupported unit size value: %u", raw_size);
-        }
-      }
+      ESP_LOGD(TAG, "getting valve status");
+      write_command_(CMD_GET_VALVE_STATUS, nullptr, 0);
     }
+  }
 
-    inline bool ComfoAirComponent::set_unit_size(uint8_t raw_size)
+  void get_error_status_()
+  {
+    if (filter_status != nullptr || filter_status_full != nullptr)
     {
-      if (raw_size != 1 && raw_size != 2)
-      {
-        ESP_LOGW(TAG, "Ignoring invalid unit size request: %u", raw_size);
-        return false;
-      }
-
-      if (!status_payload_valid_)
-      {
-        ESP_LOGW(TAG, "Unit size cannot be changed before initial status is received");
-        publish_size_entities_(current_unit_size_);
-        return false;
-      }
-
-      if (status_payload_[3] == raw_size)
-      {
-        publish_size_entities_(raw_size);
-        return true;
-      }
-
-      uint8_t payload[sizeof(status_payload_)];
-      memcpy(payload, status_payload_, sizeof(status_payload_));
-      payload[3] = raw_size;
-
-      ESP_LOGI(TAG, "Setting unit size to %s", unit_size_text_label_(raw_size));
-      write_command_(CMD_SET_STATUS, payload, sizeof(payload));
-
-      status_payload_[3] = raw_size;
-      publish_size_entities_(raw_size);
-
-      return true;
+      ESP_LOGD(TAG, "getting error status");
+      write_command_(CMD_GET_FAULTS, nullptr, 0);
     }
+  }
 
-    inline void ComfoAirComponent::set_size_select(ComfoAirSizeSelect *size_select)
+  void get_bypass_control_status_()
+  {
+    if (bypass_factor != nullptr || bypass_step != nullptr || bypass_correction != nullptr || summer_mode != nullptr)
     {
-      this->size_select_ = size_select;
-      if (this->size_select_ != nullptr)
-      {
-        this->size_select_->set_parent(this);
-        if (const char *option = this->unit_size_option_label_(this->current_unit_size_))
-        {
-          this->size_select_->publish_state(option);
-        }
-      }
+      ESP_LOGD(TAG, "getting bypass control");
+      write_command_(CMD_GET_BYPASS_CONTROL_STATUS, nullptr, 0);
     }
+  }
 
-    inline void ComfoAirSizeSelect::control(const std::string &value)
+  void get_temperature_()
+  {
+    if (outside_air_temperature != nullptr || supply_air_temperature != nullptr || return_air_temperature != nullptr ||
+        outside_air_temperature != nullptr)
     {
-      if (this->parent_ == nullptr)
-      {
-        ESP_LOGW(TAG, "Unit size select has no parent component configured");
-        return;
-      }
-
-      auto index = this->index_of(value);
-      if (!index.has_value())
-      {
-        ESP_LOGW(TAG, "Unit size select received invalid option: %s", value.c_str());
-        return;
-      }
-
-      uint8_t raw_size = 0;
-      switch (index.value())
-      {
-      case 0:
-        raw_size = 1;
-        break;
-      case 1:
-        raw_size = 2;
-        break;
-      default:
-        ESP_LOGW(TAG, "Unit size select index %zu not supported", index.value());
-        return;
-      }
-
-      if (!this->parent_->set_unit_size(raw_size))
-      {
-        if (const char *current_option = this->parent_->unit_size_option_label_(this->parent_->current_unit_size_))
-        {
-          this->publish_state(current_option);
-        }
-      }
+      ESP_LOGD(TAG, "getting temperature");
+      write_command_(CMD_GET_TEMPERATURE_STATUS, nullptr, 0);
     }
+  }
 
-    inline void ComfoAirNumber::control(float value) {
-      this->publish_state(value);
-      if (this->parent_ != nullptr) {
-        this->parent_->set_fan_percentages();
-      }
-    }
-
-    inline void ComfoAirSyncButton::press_action()
+  void get_sensor_data_()
+  {
+    if (enthalpy_temperature != nullptr)
     {
-      this->parent_->set_fan_percentages();
+      ESP_LOGD(TAG, "getting sensor data");
+      write_command_(CMD_GET_SENSOR_DATA, nullptr, 0);
     }
+  }
 
-  } // namespace comfoair
+  void get_ventilation_level_()
+  {
+    ESP_LOGD(TAG, "getting ventilation level");
+    write_command_(CMD_GET_VENTILATION_LEVEL, nullptr, 0);
+  }
+
+  void get_temperatures_()
+  {
+    ESP_LOGD(TAG, "getting temperatures");
+    write_command_(CMD_GET_TEMPERATURES, nullptr, 0);
+  }
+
+  void get_operation_hours_()
+  {
+    ESP_LOGD(TAG, "getting operation hours");
+    write_command_(CMD_GET_OPERATION_HOURS, nullptr, 0);
+  }
+
+  void get_preheating_status_()
+  {
+    ESP_LOGD(TAG, "getting preheating status");
+    write_command_(CMD_GET_PREHEATING_STATUS, nullptr, 0);
+  }
+
+  void get_time_delay_()
+  {
+    ESP_LOGD(TAG, "getting time delay");
+    write_command_(CMD_GET_TIME_DELAY, nullptr, 0);
+  }
+
+  void publish_size_entities_(uint8_t raw_size);
+  const char *unit_size_text_label_(uint8_t raw_size) const;
+  const char *unit_size_option_label_(uint8_t raw_size) const;
+
+  uint8_t caRxBuffer_au8[MAX_MESSAGE_SIZE]{};
+  uint8_t caRxIdx_u8 = 0;
+  int8_t update_counter_{-10};
+  uint8_t status_payload_[8]{0};
+  bool status_payload_valid_{false};
+  uint8_t current_unit_size_{0};
+  ComfoAirSizeSelect *size_select_{nullptr};
+
+  uint8_t bootloader_version_[13]{0};
+  uint8_t firmware_version_[13]{0};
+  uint8_t connector_board_version_[14]{0};
+  const char *name{0};
+
+public:
+  text_sensor::TextSensor *type{nullptr};
+  text_sensor::TextSensor *size{nullptr};
+  text_sensor::TextSensor *filter_status{nullptr};
+  binary_sensor::BinarySensor *filter_status_full{nullptr};
+  text_sensor::TextSensor *frost_protection_level{nullptr};
+  text_sensor::TextSensor *preheating_valve{nullptr};
+  sensor::Sensor *intake_fan_speed{nullptr};
+  sensor::Sensor *exhaust_fan_speed{nullptr};
+  sensor::Sensor *intake_fan_speed_rpm{nullptr};
+  sensor::Sensor *exhaust_fan_speed_rpm{nullptr};
+  sensor::Sensor *ventilation_level{nullptr};
+  sensor::Sensor *outside_air_temperature{nullptr};
+  sensor::Sensor *supply_air_temperature{nullptr};
+  sensor::Sensor *return_air_temperature{nullptr};
+  sensor::Sensor *exhaust_air_temperature{nullptr};
+  sensor::Sensor *enthalpy_temperature{nullptr};
+  sensor::Sensor *ewt_temperature{nullptr};
+  sensor::Sensor *reheating_temperature{nullptr};
+  sensor::Sensor *kitchen_hood_temperature{nullptr};
+  sensor::Sensor *return_air_level{nullptr};
+  sensor::Sensor *supply_air_level{nullptr};
+  sensor::Sensor *bypass_factor{nullptr};
+  sensor::Sensor *bypass_step{nullptr};
+  sensor::Sensor *bypass_correction{nullptr};
+  sensor::Sensor *bypass_open_hours{nullptr};
+  sensor::Sensor *motor_current_bypass{nullptr};
+  sensor::Sensor *motor_current_preheating{nullptr};
+  sensor::Sensor *preheating_hours{nullptr};
+  sensor::Sensor *level0_hours{nullptr};
+  sensor::Sensor *level1_hours{nullptr};
+  sensor::Sensor *level2_hours{nullptr};
+  sensor::Sensor *level3_hours{nullptr};
+  binary_sensor::BinarySensor *frost_protection_active{nullptr};
+  sensor::Sensor *frost_protection_hours{nullptr};
+  sensor::Sensor *frost_protection_minutes{nullptr};
+  sensor::Sensor *filter_hours{nullptr};
+  sensor::Sensor *bypass_valve{nullptr};
+  binary_sensor::BinarySensor *bypass_present{nullptr};
+  binary_sensor::BinarySensor *enthalpy_present{nullptr};
+  binary_sensor::BinarySensor *ewt_present{nullptr};
+  binary_sensor::BinarySensor *preheating_present{nullptr};
+  binary_sensor::BinarySensor *options_present{nullptr};
+  binary_sensor::BinarySensor *fireplace_present{nullptr};
+  binary_sensor::BinarySensor *kitchen_hood_present{nullptr};
+  binary_sensor::BinarySensor *postheating_present{nullptr};
+  binary_sensor::BinarySensor *postheating_pwm_mode_present{nullptr};
+  binary_sensor::BinarySensor *bypass_valve_open{nullptr};
+  binary_sensor::BinarySensor *preheating_state{nullptr};
+  binary_sensor::BinarySensor *preheating_active{nullptr};
+  binary_sensor::BinarySensor *summer_mode{nullptr};
+  binary_sensor::BinarySensor *supply_fan_active{nullptr};
+  binary_sensor::BinarySensor *p10_active{nullptr};
+  binary_sensor::BinarySensor *p11_active{nullptr};
+  binary_sensor::BinarySensor *p12_active{nullptr};
+  binary_sensor::BinarySensor *p13_active{nullptr};
+  binary_sensor::BinarySensor *p14_active{nullptr};
+  binary_sensor::BinarySensor *p15_active{nullptr};
+  binary_sensor::BinarySensor *p16_active{nullptr};
+  binary_sensor::BinarySensor *p17_active{nullptr};
+  binary_sensor::BinarySensor *p18_active{nullptr};
+  binary_sensor::BinarySensor *p19_active{nullptr};
+  binary_sensor::BinarySensor *p90_active{nullptr};
+  binary_sensor::BinarySensor *p91_active{nullptr};
+  binary_sensor::BinarySensor *p92_active{nullptr};
+  binary_sensor::BinarySensor *p93_active{nullptr};
+  binary_sensor::BinarySensor *p94_active{nullptr};
+  binary_sensor::BinarySensor *p95_active{nullptr};
+  binary_sensor::BinarySensor *p96_active{nullptr};
+  binary_sensor::BinarySensor *p97_active{nullptr};
+  sensor::Sensor *bathroom_switch_on_delay_minutes{nullptr};
+  sensor::Sensor *bathroom_switch_off_delay_minutes{nullptr};
+  sensor::Sensor *l1_switch_off_delay_minutes{nullptr};
+  sensor::Sensor *boost_ventilation_minutes{nullptr};
+  sensor::Sensor *filter_warning_weeks{nullptr};
+  sensor::Sensor *rf_high_time_short_minutes{nullptr};
+  sensor::Sensor *rf_high_time_long_minutes{nullptr};
+  sensor::Sensor *extractor_hood_switch_off_delay_minutes{nullptr};
+  ComfoAirNumber *return_air_level_absent{nullptr};
+  ComfoAirNumber *return_air_level_low{nullptr};
+  ComfoAirNumber *return_air_level_medium{nullptr};
+  ComfoAirNumber *return_air_level_high{nullptr};
+  ComfoAirNumber *supply_air_level_absent{nullptr};
+  ComfoAirNumber *supply_air_level_low{nullptr};
+  ComfoAirNumber *supply_air_level_medium{nullptr};
+  ComfoAirNumber *supply_air_level_high{nullptr};
+  ComfoAirSyncButton *sync_button_{nullptr};
+
+  // public functions
+
+  void set_type(text_sensor::TextSensor *type) { this->type = type; };
+  void set_size(text_sensor::TextSensor *size) { this->size = size; };
+  void set_intake_fan_speed(sensor::Sensor *intake_fan_speed) { this->intake_fan_speed = intake_fan_speed; };
+  void set_exhaust_fan_speed(sensor::Sensor *exhaust_fan_speed) { this->exhaust_fan_speed = exhaust_fan_speed; };
+  void set_intake_fan_speed_rpm(sensor::Sensor *intake_fan_speed_rpm)
+  {
+    this->intake_fan_speed_rpm = intake_fan_speed_rpm;
+    this->intake_fan_speed_rpm->set_accuracy_decimals(0);
+  };
+  void set_exhaust_fan_speed_rpm(sensor::Sensor *exhaust_fan_speed_rpm)
+  {
+    this->exhaust_fan_speed_rpm = exhaust_fan_speed_rpm;
+    this->exhaust_fan_speed_rpm->set_accuracy_decimals(0);
+  };
+  void set_ventilation_level(sensor::Sensor *ventilation_level) { this->ventilation_level = ventilation_level; };
+  void set_bypass_valve(sensor::Sensor *bypass_valve) { this->bypass_valve = bypass_valve; };
+  void set_bypass_present(binary_sensor::BinarySensor *bypass_present) { this->bypass_present = bypass_present; };
+  void set_enthalpy_present(binary_sensor::BinarySensor *enthalpy_present)
+  {
+    this->enthalpy_present = enthalpy_present;
+  };
+  void set_ewt_present(binary_sensor::BinarySensor *ewt_present) { this->ewt_present = ewt_present; };
+  void set_preheating_present(binary_sensor::BinarySensor *preheating_present)
+  {
+    this->preheating_present = preheating_present;
+  };
+  void set_options_present(binary_sensor::BinarySensor *options_present) { this->options_present = options_present; };
+  void set_fireplace_present(binary_sensor::BinarySensor *fireplace_present)
+  {
+    this->fireplace_present = fireplace_present;
+  };
+  void set_kitchen_hood_present(binary_sensor::BinarySensor *kitchen_hood_present)
+  {
+    this->kitchen_hood_present = kitchen_hood_present;
+  };
+  void set_postheating_present(binary_sensor::BinarySensor *postheating_present)
+  {
+    this->postheating_present = postheating_present;
+  };
+  void set_postheating_pwm_mode_present(binary_sensor::BinarySensor *postheating_pwm_mode_present)
+  {
+    this->postheating_pwm_mode_present = postheating_pwm_mode_present;
+  };
+  void set_bypass_valve_open(binary_sensor::BinarySensor *bypass_valve_open)
+  {
+    this->bypass_valve_open = bypass_valve_open;
+  };
+  void set_preheating_state(binary_sensor::BinarySensor *preheating_state)
+  {
+    this->preheating_state = preheating_state;
+  };
+  void set_preheating_active(binary_sensor::BinarySensor *preheating_active)
+  {
+    this->preheating_active = preheating_active;
+  };
+  void set_outside_air_temperature(sensor::Sensor *outside_air_temperature)
+  {
+    this->outside_air_temperature = outside_air_temperature;
+  };
+  void set_supply_air_temperature(sensor::Sensor *supply_air_temperature)
+  {
+    this->supply_air_temperature = supply_air_temperature;
+  };
+  void set_return_air_temperature(sensor::Sensor *return_air_temperature)
+  {
+    this->return_air_temperature = return_air_temperature;
+  };
+  void set_exhaust_air_temperature(sensor::Sensor *exhaust_air_temperature)
+  {
+    this->exhaust_air_temperature = exhaust_air_temperature;
+  };
+  void set_enthalpy_temperature(sensor::Sensor *enthalpy_temperature)
+  {
+    this->enthalpy_temperature = enthalpy_temperature;
+  };
+  void set_ewt_temperature(sensor::Sensor *ewt_temperature) { this->ewt_temperature = ewt_temperature; };
+  void set_reheating_temperature(sensor::Sensor *reheating_temperature)
+  {
+    this->reheating_temperature = reheating_temperature;
+  };
+  void set_kitchen_hood_temperature(sensor::Sensor *kitchen_hood_temperature)
+  {
+    this->kitchen_hood_temperature = kitchen_hood_temperature;
+  };
+  void set_return_air_level(sensor::Sensor *return_air_level) { this->return_air_level = return_air_level; };
+  void set_supply_air_level(sensor::Sensor *supply_air_level) { this->supply_air_level = supply_air_level; };
+  void set_supply_fan_active(binary_sensor::BinarySensor *supply_fan_active)
+  {
+    this->supply_fan_active = supply_fan_active;
+  };
+  void set_filter_status(text_sensor::TextSensor *filter_status) { this->filter_status = filter_status; };
+  void set_filter_status_full(binary_sensor::BinarySensor *filter_status_full)
+  {
+    this->filter_status_full = filter_status_full;
+  };
+  void set_bypass_factor(sensor::Sensor *bypass_factor) { this->bypass_factor = bypass_factor; };
+  void set_bypass_step(sensor::Sensor *bypass_step) { this->bypass_step = bypass_step; };
+  void set_bypass_correction(sensor::Sensor *bypass_correction) { this->bypass_correction = bypass_correction; };
+  void set_bypass_open_hours(sensor::Sensor *bypass_open_hours) { this->bypass_open_hours = bypass_open_hours; };
+  void set_motor_current_bypass(sensor::Sensor *motor_current_bypass)
+  {
+    this->motor_current_bypass = motor_current_bypass;
+  };
+  void set_motor_current_preheating(sensor::Sensor *motor_current_preheating)
+  {
+    this->motor_current_preheating = motor_current_preheating;
+  };
+  void set_preheating_hours(sensor::Sensor *preheating_hours) { this->preheating_hours = preheating_hours; };
+  void set_preheating_valve(text_sensor::TextSensor *preheating_valve) { this->preheating_valve = preheating_valve; };
+  void set_level0_hours(sensor::Sensor *level0_hours) { this->level0_hours = level0_hours; };
+  void set_level1_hours(sensor::Sensor *level1_hours) { this->level1_hours = level1_hours; };
+  void set_level2_hours(sensor::Sensor *level2_hours) { this->level2_hours = level2_hours; };
+  void set_level3_hours(sensor::Sensor *level3_hours) { this->level3_hours = level3_hours; };
+  void set_frost_protection_active(binary_sensor::BinarySensor *frost_protection_active)
+  {
+    this->frost_protection_active = frost_protection_active;
+  };
+  void set_frost_protection_hours(sensor::Sensor *frost_protection_hours)
+  {
+    this->frost_protection_hours = frost_protection_hours;
+  };
+  void set_frost_protection_minutes(sensor::Sensor *frost_protection_minutes)
+  {
+    this->frost_protection_minutes = frost_protection_minutes;
+  };
+  void set_frost_protection_level(text_sensor::TextSensor *frost_protection_level)
+  {
+    this->frost_protection_level = frost_protection_level;
+  };
+  void set_filter_hours(sensor::Sensor *filter_hours) { this->filter_hours = filter_hours; };
+  void set_summer_mode(binary_sensor::BinarySensor *summer_mode) { this->summer_mode = summer_mode; };
+  void set_p10_active(binary_sensor::BinarySensor *p10_active) { this->p10_active = p10_active; };
+  void set_p11_active(binary_sensor::BinarySensor *p11_active) { this->p11_active = p11_active; };
+  void set_p12_active(binary_sensor::BinarySensor *p12_active) { this->p12_active = p12_active; };
+  void set_p13_active(binary_sensor::BinarySensor *p13_active) { this->p13_active = p13_active; };
+  void set_p14_active(binary_sensor::BinarySensor *p14_active) { this->p14_active = p14_active; };
+  void set_p15_active(binary_sensor::BinarySensor *p15_active) { this->p15_active = p15_active; };
+  void set_p16_active(binary_sensor::BinarySensor *p16_active) { this->p16_active = p16_active; };
+  void set_p17_active(binary_sensor::BinarySensor *p17_active) { this->p17_active = p17_active; };
+  void set_p18_active(binary_sensor::BinarySensor *p18_active) { this->p18_active = p18_active; };
+  void set_p19_active(binary_sensor::BinarySensor *p19_active) { this->p19_active = p19_active; };
+  void set_p90_active(binary_sensor::BinarySensor *p90_active) { this->p90_active = p90_active; };
+  void set_p91_active(binary_sensor::BinarySensor *p91_active) { this->p91_active = p91_active; };
+  void set_p92_active(binary_sensor::BinarySensor *p92_active) { this->p92_active = p92_active; };
+  void set_p93_active(binary_sensor::BinarySensor *p93_active) { this->p93_active = p93_active; };
+  void set_p94_active(binary_sensor::BinarySensor *p94_active) { this->p94_active = p94_active; };
+  void set_p95_active(binary_sensor::BinarySensor *p95_active) { this->p95_active = p95_active; };
+  void set_p96_active(binary_sensor::BinarySensor *p96_active) { this->p96_active = p96_active; };
+  void set_p97_active(binary_sensor::BinarySensor *p97_active) { this->p97_active = p97_active; };
+  void set_bathroom_switch_on_delay_minutes(sensor::Sensor *bathroom_switch_on_delay_minutes)
+  {
+    this->bathroom_switch_on_delay_minutes = bathroom_switch_on_delay_minutes;
+  };
+  void set_bathroom_switch_off_delay_minutes(sensor::Sensor *bathroom_switch_off_delay_minutes)
+  {
+    this->bathroom_switch_off_delay_minutes = bathroom_switch_off_delay_minutes;
+  };
+  void set_l1_switch_off_delay_minutes(sensor::Sensor *l1_switch_off_delay_minutes)
+  {
+    this->l1_switch_off_delay_minutes = l1_switch_off_delay_minutes;
+  };
+  void set_boost_ventilation_minutes(sensor::Sensor *boost_ventilation_minutes)
+  {
+    this->boost_ventilation_minutes = boost_ventilation_minutes;
+  };
+  void set_filter_warning_weeks(sensor::Sensor *filter_warning_weeks)
+  {
+    this->filter_warning_weeks = filter_warning_weeks;
+  };
+  void set_rf_high_time_short_minutes(sensor::Sensor *rf_high_time_short_minutes)
+  {
+    this->rf_high_time_short_minutes = rf_high_time_short_minutes;
+  };
+  void set_rf_high_time_long_minutes(sensor::Sensor *rf_high_time_long_minutes)
+  {
+    this->rf_high_time_long_minutes = rf_high_time_long_minutes;
+  };
+  void set_extractor_hood_switch_off_delay_minutes(sensor::Sensor *extractor_hood_switch_off_delay_minutes)
+  {
+    this->extractor_hood_switch_off_delay_minutes = extractor_hood_switch_off_delay_minutes;
+  };
+  void set_return_air_level_absent(ComfoAirNumber *number)
+  {
+    this->return_air_level_absent = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_return_air_level_low(ComfoAirNumber *number)
+  {
+    this->return_air_level_low = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_return_air_level_medium(ComfoAirNumber *number)
+  {
+    this->return_air_level_medium = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_return_air_level_high(ComfoAirNumber *number)
+  {
+    this->return_air_level_high = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_supply_air_level_absent(ComfoAirNumber *number)
+  {
+    this->supply_air_level_absent = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_supply_air_level_low(ComfoAirNumber *number)
+  {
+    this->supply_air_level_low = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_supply_air_level_medium(ComfoAirNumber *number)
+  {
+    this->supply_air_level_medium = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_supply_air_level_high(ComfoAirNumber *number)
+  {
+    this->supply_air_level_high = number;
+    if (number != nullptr)
+      number->set_parent(this);
+  }
+  void set_sync_fan_levels(ComfoAirSyncButton *button)
+  {
+    this->sync_button_ = button;
+    if (button != nullptr)
+      button->set_parent(this);
+  }
+};
+
+inline const char *ComfoAirComponent::unit_size_text_label_(uint8_t raw_size) const
+{
+  switch (raw_size)
+  {
+  case 1:
+    return "Large";
+  case 2:
+    return "Small";
+  default:
+    return "Unknown";
+  }
+}
+
+inline const char *ComfoAirComponent::unit_size_option_label_(uint8_t raw_size) const
+{
+  switch (raw_size)
+  {
+  case 1:
+    return "Large";
+  case 2:
+    return "Small";
+  default:
+    return nullptr;
+  }
+}
+
+inline void ComfoAirComponent::publish_size_entities_(uint8_t raw_size)
+{
+  current_unit_size_ = raw_size;
+  if (size != nullptr)
+  {
+    size->publish_state(unit_size_text_label_(raw_size));
+  }
+  if (size_select_ != nullptr)
+  {
+    if (const char *option = unit_size_option_label_(raw_size))
+    {
+      size_select_->publish_state(option);
+    }
+    else
+    {
+      ESP_LOGW(TAG, "Unsupported unit size value: %u", raw_size);
+    }
+  }
+}
+
+inline bool ComfoAirComponent::set_unit_size(uint8_t raw_size)
+{
+  if (raw_size != 1 && raw_size != 2)
+  {
+    ESP_LOGW(TAG, "Ignoring invalid unit size request: %u", raw_size);
+    return false;
+  }
+
+  if (!status_payload_valid_)
+  {
+    ESP_LOGW(TAG, "Unit size cannot be changed before initial status is received");
+    publish_size_entities_(current_unit_size_);
+    return false;
+  }
+
+  if (status_payload_[3] == raw_size)
+  {
+    publish_size_entities_(raw_size);
+    return true;
+  }
+
+  uint8_t payload[sizeof(status_payload_)];
+  memcpy(payload, status_payload_, sizeof(status_payload_));
+  payload[3] = raw_size;
+
+  ESP_LOGI(TAG, "Setting unit size to %s", unit_size_text_label_(raw_size));
+  write_command_(CMD_SET_STATUS, payload, sizeof(payload));
+
+  status_payload_[3] = raw_size;
+  publish_size_entities_(raw_size);
+
+  return true;
+}
+
+inline void ComfoAirComponent::set_size_select(ComfoAirSizeSelect *size_select)
+{
+  this->size_select_ = size_select;
+  if (this->size_select_ != nullptr)
+  {
+    this->size_select_->set_parent(this);
+    if (const char *option = this->unit_size_option_label_(this->current_unit_size_))
+    {
+      this->size_select_->publish_state(option);
+    }
+  }
+}
+
+inline void ComfoAirSizeSelect::control(const std::string &value)
+{
+  if (this->parent_ == nullptr)
+  {
+    ESP_LOGW(TAG, "Unit size select has no parent component configured");
+    return;
+  }
+
+  auto index = this->index_of(value);
+  if (!index.has_value())
+  {
+    ESP_LOGW(TAG, "Unit size select received invalid option: %s", value.c_str());
+    return;
+  }
+
+  uint8_t raw_size = 0;
+  switch (index.value())
+  {
+  case 0:
+    raw_size = 1;
+    break;
+  case 1:
+    raw_size = 2;
+    break;
+  default:
+    ESP_LOGW(TAG, "Unit size select index %zu not supported", index.value());
+    return;
+  }
+
+  if (!this->parent_->set_unit_size(raw_size))
+  {
+    if (const char *current_option = this->parent_->unit_size_option_label_(this->parent_->current_unit_size_))
+    {
+      this->publish_state(current_option);
+    }
+  }
+}
+
+inline void ComfoAirNumber::control(float value)
+{
+  this->publish_state(value);
+  if (this->parent_ != nullptr)
+  {
+    this->parent_->set_fan_percentages();
+  }
+}
+
+inline void ComfoAirSyncButton::press_action()
+{
+  if (this->parent_ != nullptr)
+  {
+    this->parent_->set_fan_percentages();
+  }
+}
+
+} // namespace comfoair
 } // namespace esphome

--- a/components/comfoair/registers.h
+++ b/components/comfoair/registers.h
@@ -5,14 +5,17 @@
 // =================================================
 
 #define COMMAND_PREFIX 0x07
-#define COMMAND_HEAD 0xF0
+#define COMMAND_HEAD_CMD 0xF0               // previously COMMAND_HEAD
+#define COMMAND_HEAD_ACK 0xF3               // previously COMMAND_ACK
 #define COMMAND_LEN_HEAD 5
 #define COMMAND_TAIL 0x0F
 #define COMMAND_LEN_TAIL 3
-#define COMMAND_ACK 0xF3
-#define COMMAND_ID_ACK 1
-#define COMMAND_IDX_DATA 4
+#define COMMAND_IDX_PREFIX 0                // new define
+#define COMMAND_IDX_HEAD 1                  // previously COMMAND_ID_ACK
+#define COMMAND_IDX_EXTENDED_MSG_ID 2       // new define
 #define COMMAND_IDX_MSG_ID 3
+#define COMMAND_IDX_PROTOCOL_LENGTH 4       // previously COMMAND_IDX_DATA
+#define COMMAND_IDX_PROTOCOL_DATA_AREA 5    // new define
 
 // =================================================
 // ========== Bootloader (PC an ComfoAir) ==========
@@ -82,8 +85,8 @@ Byte[1] = Version Minor
 Byte[2] = Beta
 Byte[3-12] = Devicename (ASCII String)
 */
-#define CMD_GET_BOOTLOADER_VERSION 0x67
-#define RES_GET_BOOTLOADER_VERSION 0x68
+#define CMD_GET_BOOTLOADER_VERSION 0x67 // update case -4
+#define RES_GET_BOOTLOADER_VERSION 0x68 // implemented
 
 /*
 Data: -
@@ -94,8 +97,8 @@ Byte[1] = Version Minor
 Byte[2] = Beta
 Byte[3-12] = Devicename (ASCII String)
 */
-#define CMD_GET_FIRMWARE_VERSION 0x69
-#define RES_GET_FIRMWARE_VERSION 0x6A
+#define CMD_GET_FIRMWARE_VERSION 0x69 // update case -3
+#define RES_GET_FIRMWARE_VERSION 0x6A // implemented
 
 /*
 Data: -
@@ -111,8 +114,8 @@ Byte[13] = Version CC-Luxe
     Bit[7..4] Version Major
     Bit[3..0] = Version Minor
 */
-#define CMD_GET_CONNECTOR_BOARD_VERSION 0xA1
-#define RES_GET_CONNECTOR_BOARD_VERSION 0xA2
+#define CMD_GET_CONNECTOR_BOARD_VERSION 0xA1 // update case -2
+#define RES_GET_CONNECTOR_BOARD_VERSION 0xA2 // implemented
 
 /*
 Data: 1 byte
@@ -129,7 +132,7 @@ Byte[0] = 0x00 = Without connection
           0x04 = PC log mode
 */
 #define CMD_SET_RS232_MODE 0x9B
-#define RES_SET_RS232_MODE 0x9C
+#define RES_SET_RS232_MODE 0x9C // todo missing
 
 // ======================================================================
 // ========== Command list (PC to ComfoAir) / reading commands ==========
@@ -149,8 +152,8 @@ Byte[1] = Switching inputs: (1 = active / 0 = inactive)
     0x08 = heat recovery (WTW)
     0x10 = bathroom switch 2 (luxe)
 */
-#define CMD_GET_INPUTS 0x03
-#define RES_GET_INPUTS 0x04
+#define CMD_GET_INPUTS 0x03 // todo missing
+#define RES_GET_INPUTS 0x04 // todo missing
 
 /*
 Data: -
@@ -161,8 +164,8 @@ Byte[1] = Exhaust air (%)
 Byte[2..3] = Supply air fan speed (rpm**)
 Byte[4..5] = Exhaust air fan speed (rpm**)
 */
-#define CMD_GET_FAN_STATUS 0x0B
-#define RES_GET_FAN_STATUS 0x0C
+#define CMD_GET_FAN_STATUS 0x0B // update case 0
+#define RES_GET_FAN_STATUS 0x0C // implemented
 
 /*
 Data: -
@@ -173,8 +176,8 @@ Byte[1] = Preheating (1 = Open / 0 = Closed / 2 = Unknown)
 Byte[2] = Bypass motor current (ADC raw data)
 Byte[3] = Preheating motor current (ADC raw data)
 */
-#define CMD_GET_VALVE_STATUS 0x0D
-#define RES_GET_VALVE_STATUS 0x0E
+#define CMD_GET_VALVE_STATUS 0x0D // update case 1
+#define RES_GET_VALVE_STATUS 0x0E // implemented
 
 /*
 Data: -
@@ -185,8 +188,8 @@ Byte[1] = T2 / supply air (°C*)
 Byte[2] = T3 / exhaust air (in) (°C*)
 Byte[3] = T4 / exhaust air (out) (°C*)
 */
-#define CMD_GET_TEMPERATURE_STATUS 0x0F
-#define RES_GET_TEMPERATURE_STATUS 0x10
+#define CMD_GET_TEMPERATURE_STATUS 0x0F // implemented
+#define RES_GET_TEMPERATURE_STATUS 0x10 // implemented
 
 /*
 Data: -
@@ -195,8 +198,8 @@ Response: 1 byte
 Byte[0] = 0x00 = Nothing pressed
           0xFF = Error
 */
-#define CMD_GET_BUTTON_STATUS 0x11
-#define RES_GET_BUTTON_STATUS 0x12
+#define CMD_GET_BUTTON_STATUS 0x11 // todo missing
+#define RES_GET_BUTTON_STATUS 0x12 // todo missing
 
 /*
 Data: -
@@ -207,8 +210,8 @@ Byte[1] = Analog 2 (0..255 = 0..10V)
 Byte[2] = Analog 3 (0..255 = 0..10V)
 Byte[3] = Analog 4 (0..255 = 0..10V)
 */
-#define CMD_GET_ANALOG_INPUTS 0x13
-#define RES_GET_ANALOG_INPUTS 0x14
+#define CMD_GET_ANALOG_INPUTS 0x13 // todo missing
+#define RES_GET_ANALOG_INPUTS 0x14 // todo missing
 
 /*
 Data: -
@@ -232,8 +235,8 @@ Byte[14] = Analog 3 from desired (%)
 Byte[15] = Analog 4 to desired (%)
 Byte[16] = Analog 4 from desired (%)
 */
-#define CMD_GET_SENSOR_DATA 0x97
-#define RES_GET_SENSOR_DATA 0x98
+#define CMD_GET_SENSOR_DATA 0x97 // implemented
+#define RES_GET_SENSOR_DATA 0x98 // implemented
 
 /*
 Data: -
@@ -274,8 +277,8 @@ Byte[16] = Analog RF Max Setting (%)
 Byte[17] = Analog RF setpoint (%)
 Byte[18] = Priority control (0 = analog inputs / 1 = weekly program)
 */
-#define CMD_GET_ANALOG_VALUES 0x9D
-#define RES_GET_ANALOG_VALUES 0x9E
+#define CMD_GET_ANALOG_VALUES 0x9D // todo missing
+#define RES_GET_ANALOG_VALUES 0x9E // todo missing
 
 /*
 Data: -
@@ -290,8 +293,8 @@ Byte[5] = RF high time short (min)
 Byte[6] = RF high time long (min)
 Byte[7] = Kitchen hood switch-off delay (min)
 */
-#define CMD_GET_TIME_DELAY 0xC9
-#define RES_GET_TIME_DELAY 0xCA
+#define CMD_GET_TIME_DELAY 0xC9 // update case 9
+#define RES_GET_TIME_DELAY 0xCA // implemented
 
 /*
 Data: -
@@ -312,8 +315,8 @@ Byte[11] = Supply air high / level 3 (%)
 Byte[12] = ..
 Byte[13] = ..
 */
-#define CMD_GET_VENTILATION_LEVEL 0xCD
-#define RES_GET_VENTILATION_LEVEL 0xCE
+#define CMD_GET_VENTILATION_LEVEL 0xCD // update case 3
+#define RES_GET_VENTILATION_LEVEL 0xCE // implemented
 
 /*
 Data: -
@@ -336,8 +339,8 @@ Byte[6] = Temperature EWT (°C*)
 Byte[7] = Temperature afterheating (°C*)
 Byte[8] = Temperature kitchen hood (°C*)
 */
-#define CMD_GET_TEMPERATURES 0xD1
-#define RES_GET_TEMPERATURES 0xD2
+#define CMD_GET_TEMPERATURES 0xD1 // update case 4
+#define RES_GET_TEMPERATURES 0xD2 // implemented
 
 /*
 Data: -
@@ -369,8 +372,8 @@ Byte[9] = Enthalpy present (1 = present / 0 = absent / 2 = without Sensor)
 Byte[10] = EWT present (1 = regulated / 0 = absent / 2 = unregulated)
 
 */
-#define CMD_GET_STATUS 0xD5
-#define RES_GET_STATUS 0xD6
+#define CMD_GET_STATUS 0xD5 // update case -1
+#define RES_GET_STATUS 0xD6 // implemented
 
 /*
 Data: -
@@ -447,8 +450,8 @@ Byte[16] = Last but one error A (high):
     0x40 = A15
     0x80 = A0
 */
-#define CMD_GET_FAULTS 0xD9
-#define RES_GET_FAULTS 0xDA
+#define CMD_GET_FAULTS 0xD9 // update case 5
+#define RES_GET_FAULTS 0xDA // implemented
 
 /*
 Data: -
@@ -463,8 +466,8 @@ Bytes[13-14] = Operating hours bypass open (h) (Byte[14] = Low Byte)
 Bytes[15-16] = Filter operating hours (h) (Byte[16] = Low Byte)
 Bytes[17-19] = Operating hours high / level 3 (h) (Byte[19] = Low Byte)
 */
-#define CMD_GET_OPERATION_HOURS 0xDD
-#define RES_GET_OPERATION_HOURS 0xDE
+#define CMD_GET_OPERATION_HOURS 0xDD // update case 7
+#define RES_GET_OPERATION_HOURS 0xDE // implemented
 
 /*
 Data: -
@@ -478,8 +481,8 @@ Byte[4] = Bypass correction
 Byte[5] = 0x00
 Byte[6] = Summer mode (1 = yes / 0 = no (winter))
 */
-#define CMD_GET_BYPASS_CONTROL_STATUS 0xDF
-#define RES_GET_BYPASS_CONTROL_STATUS 0xE0
+#define CMD_GET_BYPASS_CONTROL_STATUS 0xDF // update case 6
+#define RES_GET_BYPASS_CONTROL_STATUS 0xE0 // implemented
 
 /*
 Data: -
@@ -491,8 +494,8 @@ Byte[2] = Preheating (1 = active / 0 = inactive)
 Byte[3..4] = Frost minutes (min)
 Byte[5] = Frost protection (1 = extra safe / 4 = safe)
 */
-#define CMD_GET_PREHEATING_STATUS 0xE1
-#define RES_GET_PREHEATING_STATUS 0xE2
+#define CMD_GET_PREHEATING_STATUS 0xE1 // update case 8
+#define RES_GET_PREHEATING_STATUS 0xE2 // implemented
 
 /*
 Data: -
@@ -506,8 +509,8 @@ Byte[4] = RF ID
 Byte[5] = Module present
 Byte[6] = Self-learning mode active
 */
-#define CMD_GET_RF_STATUS 0xE5
-#define RES_GET_RF_STATUS 0xE6
+#define CMD_GET_RF_STATUS 0xE5 // todo missing
+#define RES_GET_RF_STATUS 0xE6 // todo missing
 
 /*
 Data: -
@@ -522,8 +525,8 @@ Byte[5] =
 Byte[6] =
 Byte[7] = Latest value (°C)
 */
-#define CMD_GET_LAST_8_TIMES_PREHEATING 0xE9
-#define RES_GET_LAST_8_TIMES_PREHEATING 0xEA
+#define CMD_GET_LAST_8_TIMES_PREHEATING 0xE9 // todo missing
+#define RES_GET_LAST_8_TIMES_PREHEATING 0xEA // todo missing
 
 /*
 Data: -
@@ -537,8 +540,8 @@ Byte[4] = Post-heating performance
 Byte[5] = Post-heating power I parameter
 Byte[6] = Reheating T desired (°C)
 */
-#define CMD_EWT_POST_HEATING 0xEB
-#define RES_EWT_POST_HEATING 0xEC
+#define CMD_EWT_POST_HEATING 0xEB // todo missing
+#define RES_EWT_POST_HEATING 0xEC // todo missing
 
 // ====================================================================
 // ========== Command list (PC to ComfoAir) / write commands ==========
@@ -554,8 +557,9 @@ Byte[0] = 0x00 = Auto
 
 Response: ACK
 */
-#define CMD_SET_LEVEL 0x99
-#define RES_SET_LEVEL COMMAND_ACK
+#define CMD_SET_LEVEL 0x99 // implemented
+#define CMD_SET_LEVEL_LENGTH 1
+#define RES_SET_LEVEL COMMAND_HEAD_ACK
 
 /*
 Data: 19 bytes
@@ -596,8 +600,8 @@ Byte[18] = Priority control (0 = analog inputs / 1 = weekly program)
 
 Response: ACK
 */
-#define CMD_SET_ANALOG_VALUES 0x9F
-#define RES_SET_ANALOG_VALUES COMMAND_ACK
+#define CMD_SET_ANALOG_VALUES 0x9F // todo missing
+#define RES_SET_ANALOG_VALUES COMMAND_HEAD_ACK
 
 /*
 Data: 8 bytes
@@ -612,8 +616,8 @@ Byte[7] = Kitchen hood switch-off delay (min)
 
 Response: ACK
 */
-#define CMD_SET_TIME_DELAY 0xCB
-#define RES_SET_TIME_DELAY COMMAND_ACK
+#define CMD_SET_TIME_DELAY 0xCB // todo missing
+#define RES_SET_TIME_DELAY COMMAND_HEAD_ACK
 
 /*
 Data: 9 bytes
@@ -629,8 +633,9 @@ Byte[8] =
 
 Response: ACK
 */
-#define CMD_SET_VENTILATION_LEVEL 0xCF
-#define RES_SET_VENTILATION_LEVEL COMMAND_ACK
+#define CMD_SET_VENTILATION_LEVEL 0xCF // todo missing
+#define CMD_SET_VENTILATION_LEVEL_LENGTH 9
+#define RES_SET_VENTILATION_LEVEL COMMAND_HEAD_ACK
 
 /*
 Data: 1 byte
@@ -638,8 +643,9 @@ Byte[0] = Comfort temperature (°C*)
 
 Response: ACK
 */
-#define CMD_SET_COMFORT_TEMPERATURE 0xD3
-#define RES_SET_COMFORT_TEMPERATURE COMMAND_ACK
+#define CMD_SET_COMFORT_TEMPERATURE 0xD3 // implemented
+#define CMD_SET_COMFORT_TEMPERATURE_LENGTH 1
+#define RES_SET_COMFORT_TEMPERATURE COMMAND_HEAD_ACK
 
 /*
 Data: 8 bytes
@@ -659,8 +665,8 @@ Byte[7] = EWT present (1 = regulated / 0 = absent / 2 = unregulated)
 
 Response: ACK
 */
-#define CMD_SET_STATUS 0xD7
-#define RES_SET_STATUS COMMAND_ACK
+#define CMD_SET_STATUS 0xD7 // todo missing
+#define RES_SET_STATUS COMMAND_HEAD_ACK
 
 /*
 Data: 4 bytes
@@ -671,8 +677,9 @@ Byte[3] = Reset filter operating hours (1 = reset / 0 = -)
 
 Response: ACK
 */
-#define CMD_RESET_AND_SELF_TEST 0xDB
-#define RES_RESET_AND_SELF_TEST COMMAND_ACK
+#define CMD_RESET_AND_SELF_TEST 0xDB // implemented
+#define CMD_RESET_AND_SELF_TEST_LENGTH 4
+#define RES_RESET_AND_SELF_TEST COMMAND_HEAD_ACK
 
 /*
 Data: 5 bytes
@@ -687,8 +694,8 @@ Byte[4] = Reheating T desired (°C)
 
 Response: ACK
 */
-#define CMD_SET_EWT_POSTHEATING 0xED
-#define RES_SET_EWT_POSTHEATING COMMAND_ACK
+#define CMD_SET_EWT_POSTHEATING 0xED // todo missing
+#define RES_SET_EWT_POSTHEATING COMMAND_HEAD_ACK
 
 // ================================================
 // ========== Test mode (PC to ComfoAir) ==========
@@ -700,8 +707,8 @@ Data: -
 Response: -
 Confirmation test mode
 */
-#define CMD_SET_TEST_MODE 0x01
-#define RES_SET_TEST_MODE 0x02
+#define CMD_SET_TEST_MODE 0x01 // todo missing
+#define RES_SET_TEST_MODE 0x02 // todo missing
 
 /*
 Data: 2 bytes
@@ -717,8 +724,8 @@ Byte[1] = Return message
 
 Response: -
 */
-#define CMD_SET_OUTPUTS 0x05
-#define RES_SET_OUTPUTS []
+#define CMD_SET_OUTPUTS 0x05 // todo missing
+#define RES_SET_OUTPUTS [] // todo missing
 
 /*
 Data: 3 bytes
@@ -728,8 +735,8 @@ Byte[2] = Post-heating (%)
 
 Response: -
 */
-#define CMD_SET_ANALOG_OUTPUTS 0x07
-#define RES_SET_ANALOG_OUTPUTS []
+#define CMD_SET_ANALOG_OUTPUTS 0x07 // todo missing
+#define RES_SET_ANALOG_OUTPUTS [] // todo missing
 
 /*
 Data: 2 bytes
@@ -738,8 +745,8 @@ Byte[1] = Preheating (1 = open / 0 = closed / 3 = stop)
 
 Response:
 */
-#define CMD_SET_FLAPS 0x09
-#define RES_SET_FLAPS []
+#define CMD_SET_FLAPS 0x09 // todo missing
+#define RES_SET_FLAPS [] // todo missing
 
 /*
 Data: -
@@ -747,8 +754,8 @@ Data: -
 Response: -
 Confirmation end of test mode
 */
-#define CMD_EXIT_TEST_MODE 0x19
-#define RES_EXIT_TEST_MODE 0x1A
+#define CMD_EXIT_TEST_MODE 0x19 // todo missing
+#define RES_EXIT_TEST_MODE 0x1A // todo missing
 
 // ========================================================
 // ========== Command list (CC-Ease to ComfoAir) ==========
@@ -761,18 +768,18 @@ Response: -
 
 See ComfoAir command list on CC-Ease
 */
-#define CMD_GET_DATA 0x33
-#define RES_GET_DATA_1 0x38
-#define RES_GET_DATA_2 0x3E
-#define RES_GET_DATA_3 0x40
-#define RES_GET_DATA_4 0x98
-#define RES_GET_DATA_5 0x9C
-#define RES_GET_DATA_6 0xAA
-#define RES_GET_DATA_7 0xCE
-#define RES_GET_DATA_8 0xD2
-#define RES_GET_DATA_9 0xE0
-#define RES_GET_DATA_10 0xE2
-#define RES_GET_DATA_11 0xEC
+#define CMD_GET_DATA 0x33 // todo missing
+#define RES_GET_DATA_1 0x38 // todo missing
+#define RES_GET_DATA_2 0x3E // todo missing
+#define RES_GET_DATA_3 0x40 // todo missing
+#define RES_GET_DATA_4 0x98 // todo missing
+#define RES_GET_DATA_5 0x9C // todo missing
+#define RES_GET_DATA_6 0xAA // todo missing
+#define RES_GET_DATA_7 0xCE // todo missing
+#define RES_GET_DATA_8 0xD2 // todo missing
+#define RES_GET_DATA_9 0xE0 // todo missing
+#define RES_GET_DATA_10 0xE2 // todo missing
+#define RES_GET_DATA_11 0xEC // todo missing
 
 /*
 Data: 5 bytes
@@ -797,8 +804,8 @@ Response: -
 See ComfoAir command list on CC-Ease
 
 */
-#define CMD_GET_CC_EASE_PARAMETERS 0x35
-#define RES_GET_CC_EASE_PARAMETERS 0x3C
+#define CMD_GET_CC_EASE_PARAMETERS 0x35 // todo missing
+#define RES_GET_CC_EASE_PARAMETERS 0x3C // todo missing
 
 /*
 Data: 7 bytes
@@ -814,8 +821,8 @@ Byte[6] Status bits
 Response: -
 See ComfoAir command list on CC-Ease
 */
-#define CMD_CCEASE_BUTTON_STATUS 0x37
-#define RES_CCEASE_BUTTON_STATUS 0x3C
+#define CMD_CCEASE_BUTTON_STATUS 0x37 // todo missing
+#define RES_CCEASE_BUTTON_STATUS 0x3C // todo missing
 
 /*
 Data: 16 bytes
@@ -839,8 +846,8 @@ Byte[15] = Data byte 10
 Response: -
 See ComfoAir command list on CC-Ease
 */
-#define CMD_GET_RF_COMMAND 0x39
-#define RES_GET_RF_COMMAND 0x40
+#define CMD_GET_RF_COMMAND 0x39 // todo missing
+#define RES_GET_RF_COMMAND 0x40 // todo missing
 
 // ========================================================
 // ========== Command list (ComfoAir to CC-Ease) ==========
@@ -863,8 +870,8 @@ Byte[4] = Backlight (fixed at 100%)
 
 Response:
 */
-#define CMD_SET_PARAMETER 0x38
-#define RES_SET_PARAMETER []
+#define CMD_SET_PARAMETER 0x38 // todo missing
+#define RES_SET_PARAMETER [] // todo missing
 
 /*
 Data: 10 bytes
@@ -961,8 +968,8 @@ Byte[9] = (1 = on / 0 = off)
 
 Response: -
 */
-#define CMD_SET_DISPLAY 0x39
-#define RES_SET_DISPLAY []
+#define CMD_SET_DISPLAY 0x39 // todo missing // todo this differs from Protokollbeschreibung_ComfoAir.pdf which says 0x3C
+#define RES_SET_DISPLAY [] // todo missing
 
 /*
 Data: 4 bytes
@@ -973,8 +980,8 @@ Byte[3] = RF Address 1 (High Byte)
 
 Response: -
 */
-#define CMD_SET_RF_ADDRESS 0x3E
-#define RES_SET_RF_ADDRESS []
+#define CMD_SET_RF_ADDRESS 0x3E // todo missing
+#define RES_SET_RF_ADDRESS [] // todo missing
 
 /*
 Data: 21 bytes
@@ -1005,5 +1012,5 @@ Byte[20] = Control bits
 
 Response:
 */
-#define CMD_SEND_RF_COMMAND 0x40
-#define RES_SEND_RF_COMMAND []
+#define CMD_SEND_RF_COMMAND 0x40 // todo missing
+#define RES_SEND_RF_COMMAND [] // todo missing

--- a/components/comfoair/registers.h
+++ b/components/comfoair/registers.h
@@ -5,14 +5,17 @@
 // =================================================
 
 #define COMMAND_PREFIX 0x07
-#define COMMAND_HEAD 0xF0
+#define COMMAND_HEAD_CMD 0xF0 // previously COMMAND_HEAD
+#define COMMAND_HEAD_ACK 0xF3 // previously COMMAND_ACK
 #define COMMAND_LEN_HEAD 5
 #define COMMAND_TAIL 0x0F
 #define COMMAND_LEN_TAIL 3
-#define COMMAND_ACK 0xF3
-#define COMMAND_ID_ACK 1
-#define COMMAND_IDX_DATA 4
+#define COMMAND_IDX_PREFIX 0          // new define
+#define COMMAND_IDX_HEAD 1            // previously COMMAND_ID_ACK
+#define COMMAND_IDX_EXTENDED_MSG_ID 2 // new define
 #define COMMAND_IDX_MSG_ID 3
+#define COMMAND_IDX_PROTOCOL_LENGTH 4    // previously COMMAND_IDX_DATA
+#define COMMAND_IDX_PROTOCOL_DATA_AREA 5 // new define
 
 // =================================================
 // ========== Bootloader (PC an ComfoAir) ==========
@@ -82,8 +85,8 @@ Byte[1] = Version Minor
 Byte[2] = Beta
 Byte[3-12] = Devicename (ASCII String)
 */
-#define CMD_GET_BOOTLOADER_VERSION 0x67
-#define RES_GET_BOOTLOADER_VERSION 0x68
+#define CMD_GET_BOOTLOADER_VERSION 0x67 // update case -4
+#define RES_GET_BOOTLOADER_VERSION 0x68 // implemented
 
 /*
 Data: -
@@ -94,8 +97,8 @@ Byte[1] = Version Minor
 Byte[2] = Beta
 Byte[3-12] = Devicename (ASCII String)
 */
-#define CMD_GET_FIRMWARE_VERSION 0x69
-#define RES_GET_FIRMWARE_VERSION 0x6A
+#define CMD_GET_FIRMWARE_VERSION 0x69 // update case -3
+#define RES_GET_FIRMWARE_VERSION 0x6A // implemented
 
 /*
 Data: -
@@ -111,8 +114,8 @@ Byte[13] = Version CC-Luxe
     Bit[7..4] Version Major
     Bit[3..0] = Version Minor
 */
-#define CMD_GET_CONNECTOR_BOARD_VERSION 0xA1
-#define RES_GET_CONNECTOR_BOARD_VERSION 0xA2
+#define CMD_GET_CONNECTOR_BOARD_VERSION 0xA1 // update case -2
+#define RES_GET_CONNECTOR_BOARD_VERSION 0xA2 // implemented
 
 /*
 Data: 1 byte
@@ -129,7 +132,7 @@ Byte[0] = 0x00 = Without connection
           0x04 = PC log mode
 */
 #define CMD_SET_RS232_MODE 0x9B
-#define RES_SET_RS232_MODE 0x9C
+#define RES_SET_RS232_MODE 0x9C // todo missing
 
 // ======================================================================
 // ========== Command list (PC to ComfoAir) / reading commands ==========
@@ -149,8 +152,8 @@ Byte[1] = Switching inputs: (1 = active / 0 = inactive)
     0x08 = heat recovery (WTW)
     0x10 = bathroom switch 2 (luxe)
 */
-#define CMD_GET_INPUTS 0x03
-#define RES_GET_INPUTS 0x04
+#define CMD_GET_INPUTS 0x03 // todo missing
+#define RES_GET_INPUTS 0x04 // todo missing
 
 /*
 Data: -
@@ -161,8 +164,8 @@ Byte[1] = Exhaust air (%)
 Byte[2..3] = Supply air fan speed (rpm**)
 Byte[4..5] = Exhaust air fan speed (rpm**)
 */
-#define CMD_GET_FAN_STATUS 0x0B
-#define RES_GET_FAN_STATUS 0x0C
+#define CMD_GET_FAN_STATUS 0x0B // update case 0
+#define RES_GET_FAN_STATUS 0x0C // implemented
 
 /*
 Data: -
@@ -173,8 +176,8 @@ Byte[1] = Preheating (1 = Open / 0 = Closed / 2 = Unknown)
 Byte[2] = Bypass motor current (ADC raw data)
 Byte[3] = Preheating motor current (ADC raw data)
 */
-#define CMD_GET_VALVE_STATUS 0x0D
-#define RES_GET_VALVE_STATUS 0x0E
+#define CMD_GET_VALVE_STATUS 0x0D // update case 1
+#define RES_GET_VALVE_STATUS 0x0E // implemented
 
 /*
 Data: -
@@ -185,8 +188,8 @@ Byte[1] = T2 / supply air (°C*)
 Byte[2] = T3 / exhaust air (in) (°C*)
 Byte[3] = T4 / exhaust air (out) (°C*)
 */
-#define CMD_GET_TEMPERATURE_STATUS 0x0F
-#define RES_GET_TEMPERATURE_STATUS 0x10
+#define CMD_GET_TEMPERATURE_STATUS 0x0F // implemented
+#define RES_GET_TEMPERATURE_STATUS 0x10 // implemented
 
 /*
 Data: -
@@ -195,8 +198,8 @@ Response: 1 byte
 Byte[0] = 0x00 = Nothing pressed
           0xFF = Error
 */
-#define CMD_GET_BUTTON_STATUS 0x11
-#define RES_GET_BUTTON_STATUS 0x12
+#define CMD_GET_BUTTON_STATUS 0x11 // todo missing
+#define RES_GET_BUTTON_STATUS 0x12 // todo missing
 
 /*
 Data: -
@@ -207,8 +210,8 @@ Byte[1] = Analog 2 (0..255 = 0..10V)
 Byte[2] = Analog 3 (0..255 = 0..10V)
 Byte[3] = Analog 4 (0..255 = 0..10V)
 */
-#define CMD_GET_ANALOG_INPUTS 0x13
-#define RES_GET_ANALOG_INPUTS 0x14
+#define CMD_GET_ANALOG_INPUTS 0x13 // todo missing
+#define RES_GET_ANALOG_INPUTS 0x14 // todo missing
 
 /*
 Data: -
@@ -232,8 +235,8 @@ Byte[14] = Analog 3 from desired (%)
 Byte[15] = Analog 4 to desired (%)
 Byte[16] = Analog 4 from desired (%)
 */
-#define CMD_GET_SENSOR_DATA 0x97
-#define RES_GET_SENSOR_DATA 0x98
+#define CMD_GET_SENSOR_DATA 0x97 // implemented
+#define RES_GET_SENSOR_DATA 0x98 // implemented
 
 /*
 Data: -
@@ -274,8 +277,8 @@ Byte[16] = Analog RF Max Setting (%)
 Byte[17] = Analog RF setpoint (%)
 Byte[18] = Priority control (0 = analog inputs / 1 = weekly program)
 */
-#define CMD_GET_ANALOG_VALUES 0x9D
-#define RES_GET_ANALOG_VALUES 0x9E
+#define CMD_GET_ANALOG_VALUES 0x9D // todo missing
+#define RES_GET_ANALOG_VALUES 0x9E // todo missing
 
 /*
 Data: -
@@ -290,8 +293,8 @@ Byte[5] = RF high time short (min)
 Byte[6] = RF high time long (min)
 Byte[7] = Kitchen hood switch-off delay (min)
 */
-#define CMD_GET_TIME_DELAY 0xC9
-#define RES_GET_TIME_DELAY 0xCA
+#define CMD_GET_TIME_DELAY 0xC9 // update case 9
+#define RES_GET_TIME_DELAY 0xCA // implemented
 
 /*
 Data: -
@@ -312,8 +315,8 @@ Byte[11] = Supply air high / level 3 (%)
 Byte[12] = ..
 Byte[13] = ..
 */
-#define CMD_GET_VENTILATION_LEVEL 0xCD
-#define RES_GET_VENTILATION_LEVEL 0xCE
+#define CMD_GET_VENTILATION_LEVEL 0xCD // update case 3
+#define RES_GET_VENTILATION_LEVEL 0xCE // implemented
 
 /*
 Data: -
@@ -336,8 +339,8 @@ Byte[6] = Temperature EWT (°C*)
 Byte[7] = Temperature afterheating (°C*)
 Byte[8] = Temperature kitchen hood (°C*)
 */
-#define CMD_GET_TEMPERATURES 0xD1
-#define RES_GET_TEMPERATURES 0xD2
+#define CMD_GET_TEMPERATURES 0xD1 // update case 4
+#define RES_GET_TEMPERATURES 0xD2 // implemented
 
 /*
 Data: -
@@ -369,8 +372,8 @@ Byte[9] = Enthalpy present (1 = present / 0 = absent / 2 = without Sensor)
 Byte[10] = EWT present (1 = regulated / 0 = absent / 2 = unregulated)
 
 */
-#define CMD_GET_STATUS 0xD5
-#define RES_GET_STATUS 0xD6
+#define CMD_GET_STATUS 0xD5 // update case -1
+#define RES_GET_STATUS 0xD6 // implemented
 
 /*
 Data: -
@@ -447,8 +450,8 @@ Byte[16] = Last but one error A (high):
     0x40 = A15
     0x80 = A0
 */
-#define CMD_GET_FAULTS 0xD9
-#define RES_GET_FAULTS 0xDA
+#define CMD_GET_FAULTS 0xD9 // update case 5
+#define RES_GET_FAULTS 0xDA // implemented
 
 /*
 Data: -
@@ -463,8 +466,8 @@ Bytes[13-14] = Operating hours bypass open (h) (Byte[14] = Low Byte)
 Bytes[15-16] = Filter operating hours (h) (Byte[16] = Low Byte)
 Bytes[17-19] = Operating hours high / level 3 (h) (Byte[19] = Low Byte)
 */
-#define CMD_GET_OPERATION_HOURS 0xDD
-#define RES_GET_OPERATION_HOURS 0xDE
+#define CMD_GET_OPERATION_HOURS 0xDD // update case 7
+#define RES_GET_OPERATION_HOURS 0xDE // implemented
 
 /*
 Data: -
@@ -478,8 +481,8 @@ Byte[4] = Bypass correction
 Byte[5] = 0x00
 Byte[6] = Summer mode (1 = yes / 0 = no (winter))
 */
-#define CMD_GET_BYPASS_CONTROL_STATUS 0xDF
-#define RES_GET_BYPASS_CONTROL_STATUS 0xE0
+#define CMD_GET_BYPASS_CONTROL_STATUS 0xDF // update case 6
+#define RES_GET_BYPASS_CONTROL_STATUS 0xE0 // implemented
 
 /*
 Data: -
@@ -491,8 +494,8 @@ Byte[2] = Preheating (1 = active / 0 = inactive)
 Byte[3..4] = Frost minutes (min)
 Byte[5] = Frost protection (1 = extra safe / 4 = safe)
 */
-#define CMD_GET_PREHEATING_STATUS 0xE1
-#define RES_GET_PREHEATING_STATUS 0xE2
+#define CMD_GET_PREHEATING_STATUS 0xE1 // update case 8
+#define RES_GET_PREHEATING_STATUS 0xE2 // implemented
 
 /*
 Data: -
@@ -506,8 +509,8 @@ Byte[4] = RF ID
 Byte[5] = Module present
 Byte[6] = Self-learning mode active
 */
-#define CMD_GET_RF_STATUS 0xE5
-#define RES_GET_RF_STATUS 0xE6
+#define CMD_GET_RF_STATUS 0xE5 // todo missing
+#define RES_GET_RF_STATUS 0xE6 // todo missing
 
 /*
 Data: -
@@ -522,8 +525,8 @@ Byte[5] =
 Byte[6] =
 Byte[7] = Latest value (°C)
 */
-#define CMD_GET_LAST_8_TIMES_PREHEATING 0xE9
-#define RES_GET_LAST_8_TIMES_PREHEATING 0xEA
+#define CMD_GET_LAST_8_TIMES_PREHEATING 0xE9 // todo missing
+#define RES_GET_LAST_8_TIMES_PREHEATING 0xEA // todo missing
 
 /*
 Data: -
@@ -537,8 +540,8 @@ Byte[4] = Post-heating performance
 Byte[5] = Post-heating power I parameter
 Byte[6] = Reheating T desired (°C)
 */
-#define CMD_EWT_POST_HEATING 0xEB
-#define RES_EWT_POST_HEATING 0xEC
+#define CMD_EWT_POST_HEATING 0xEB // todo missing
+#define RES_EWT_POST_HEATING 0xEC // todo missing
 
 // ====================================================================
 // ========== Command list (PC to ComfoAir) / write commands ==========
@@ -554,8 +557,9 @@ Byte[0] = 0x00 = Auto
 
 Response: ACK
 */
-#define CMD_SET_LEVEL 0x99
-#define RES_SET_LEVEL COMMAND_ACK
+#define CMD_SET_LEVEL 0x99 // implemented
+#define CMD_SET_LEVEL_LENGTH 1
+#define RES_SET_LEVEL COMMAND_HEAD_ACK
 
 /*
 Data: 19 bytes
@@ -596,8 +600,8 @@ Byte[18] = Priority control (0 = analog inputs / 1 = weekly program)
 
 Response: ACK
 */
-#define CMD_SET_ANALOG_VALUES 0x9F
-#define RES_SET_ANALOG_VALUES COMMAND_ACK
+#define CMD_SET_ANALOG_VALUES 0x9F // todo missing
+#define RES_SET_ANALOG_VALUES COMMAND_HEAD_ACK
 
 /*
 Data: 8 bytes
@@ -612,8 +616,8 @@ Byte[7] = Kitchen hood switch-off delay (min)
 
 Response: ACK
 */
-#define CMD_SET_TIME_DELAY 0xCB
-#define RES_SET_TIME_DELAY COMMAND_ACK
+#define CMD_SET_TIME_DELAY 0xCB // todo missing
+#define RES_SET_TIME_DELAY COMMAND_HEAD_ACK
 
 /*
 Data: 9 bytes
@@ -629,8 +633,9 @@ Byte[8] =
 
 Response: ACK
 */
-#define CMD_SET_VENTILATION_LEVEL 0xCF
-#define RES_SET_VENTILATION_LEVEL COMMAND_ACK
+#define CMD_SET_VENTILATION_LEVEL 0xCF // todo missing
+#define CMD_SET_VENTILATION_LEVEL_LENGTH 9
+#define RES_SET_VENTILATION_LEVEL COMMAND_HEAD_ACK
 
 /*
 Data: 1 byte
@@ -638,8 +643,9 @@ Byte[0] = Comfort temperature (°C*)
 
 Response: ACK
 */
-#define CMD_SET_COMFORT_TEMPERATURE 0xD3
-#define RES_SET_COMFORT_TEMPERATURE COMMAND_ACK
+#define CMD_SET_COMFORT_TEMPERATURE 0xD3 // implemented
+#define CMD_SET_COMFORT_TEMPERATURE_LENGTH 1
+#define RES_SET_COMFORT_TEMPERATURE COMMAND_HEAD_ACK
 
 /*
 Data: 8 bytes
@@ -659,8 +665,8 @@ Byte[7] = EWT present (1 = regulated / 0 = absent / 2 = unregulated)
 
 Response: ACK
 */
-#define CMD_SET_STATUS 0xD7
-#define RES_SET_STATUS COMMAND_ACK
+#define CMD_SET_STATUS 0xD7 // todo missing
+#define RES_SET_STATUS COMMAND_HEAD_ACK
 
 /*
 Data: 4 bytes
@@ -671,8 +677,9 @@ Byte[3] = Reset filter operating hours (1 = reset / 0 = -)
 
 Response: ACK
 */
-#define CMD_RESET_AND_SELF_TEST 0xDB
-#define RES_RESET_AND_SELF_TEST COMMAND_ACK
+#define CMD_RESET_AND_SELF_TEST 0xDB // implemented
+#define CMD_RESET_AND_SELF_TEST_LENGTH 4
+#define RES_RESET_AND_SELF_TEST COMMAND_HEAD_ACK
 
 /*
 Data: 5 bytes
@@ -687,8 +694,8 @@ Byte[4] = Reheating T desired (°C)
 
 Response: ACK
 */
-#define CMD_SET_EWT_POSTHEATING 0xED
-#define RES_SET_EWT_POSTHEATING COMMAND_ACK
+#define CMD_SET_EWT_POSTHEATING 0xED // todo missing
+#define RES_SET_EWT_POSTHEATING COMMAND_HEAD_ACK
 
 // ================================================
 // ========== Test mode (PC to ComfoAir) ==========
@@ -700,8 +707,8 @@ Data: -
 Response: -
 Confirmation test mode
 */
-#define CMD_SET_TEST_MODE 0x01
-#define RES_SET_TEST_MODE 0x02
+#define CMD_SET_TEST_MODE 0x01 // todo missing
+#define RES_SET_TEST_MODE 0x02 // todo missing
 
 /*
 Data: 2 bytes
@@ -717,8 +724,8 @@ Byte[1] = Return message
 
 Response: -
 */
-#define CMD_SET_OUTPUTS 0x05
-#define RES_SET_OUTPUTS []
+#define CMD_SET_OUTPUTS 0x05 // todo missing
+#define RES_SET_OUTPUTS []   // todo missing
 
 /*
 Data: 3 bytes
@@ -728,8 +735,8 @@ Byte[2] = Post-heating (%)
 
 Response: -
 */
-#define CMD_SET_ANALOG_OUTPUTS 0x07
-#define RES_SET_ANALOG_OUTPUTS []
+#define CMD_SET_ANALOG_OUTPUTS 0x07 // todo missing
+#define RES_SET_ANALOG_OUTPUTS []   // todo missing
 
 /*
 Data: 2 bytes
@@ -738,8 +745,8 @@ Byte[1] = Preheating (1 = open / 0 = closed / 3 = stop)
 
 Response:
 */
-#define CMD_SET_FLAPS 0x09
-#define RES_SET_FLAPS []
+#define CMD_SET_FLAPS 0x09 // todo missing
+#define RES_SET_FLAPS []   // todo missing
 
 /*
 Data: -
@@ -747,8 +754,8 @@ Data: -
 Response: -
 Confirmation end of test mode
 */
-#define CMD_EXIT_TEST_MODE 0x19
-#define RES_EXIT_TEST_MODE 0x1A
+#define CMD_EXIT_TEST_MODE 0x19 // todo missing
+#define RES_EXIT_TEST_MODE 0x1A // todo missing
 
 // ========================================================
 // ========== Command list (CC-Ease to ComfoAir) ==========
@@ -761,18 +768,18 @@ Response: -
 
 See ComfoAir command list on CC-Ease
 */
-#define CMD_GET_DATA 0x33
-#define RES_GET_DATA_1 0x38
-#define RES_GET_DATA_2 0x3E
-#define RES_GET_DATA_3 0x40
-#define RES_GET_DATA_4 0x98
-#define RES_GET_DATA_5 0x9C
-#define RES_GET_DATA_6 0xAA
-#define RES_GET_DATA_7 0xCE
-#define RES_GET_DATA_8 0xD2
-#define RES_GET_DATA_9 0xE0
-#define RES_GET_DATA_10 0xE2
-#define RES_GET_DATA_11 0xEC
+#define CMD_GET_DATA 0x33    // todo missing
+#define RES_GET_DATA_1 0x38  // todo missing
+#define RES_GET_DATA_2 0x3E  // todo missing
+#define RES_GET_DATA_3 0x40  // todo missing
+#define RES_GET_DATA_4 0x98  // todo missing
+#define RES_GET_DATA_5 0x9C  // todo missing
+#define RES_GET_DATA_6 0xAA  // todo missing
+#define RES_GET_DATA_7 0xCE  // todo missing
+#define RES_GET_DATA_8 0xD2  // todo missing
+#define RES_GET_DATA_9 0xE0  // todo missing
+#define RES_GET_DATA_10 0xE2 // todo missing
+#define RES_GET_DATA_11 0xEC // todo missing
 
 /*
 Data: 5 bytes
@@ -797,8 +804,8 @@ Response: -
 See ComfoAir command list on CC-Ease
 
 */
-#define CMD_GET_CC_EASE_PARAMETERS 0x35
-#define RES_GET_CC_EASE_PARAMETERS 0x3C
+#define CMD_GET_CC_EASE_PARAMETERS 0x35 // todo missing
+#define RES_GET_CC_EASE_PARAMETERS 0x3C // todo missing
 
 /*
 Data: 7 bytes
@@ -814,8 +821,8 @@ Byte[6] Status bits
 Response: -
 See ComfoAir command list on CC-Ease
 */
-#define CMD_CCEASE_BUTTON_STATUS 0x37
-#define RES_CCEASE_BUTTON_STATUS 0x3C
+#define CMD_CCEASE_BUTTON_STATUS 0x37 // todo missing
+#define RES_CCEASE_BUTTON_STATUS 0x3C // todo missing
 
 /*
 Data: 16 bytes
@@ -839,8 +846,8 @@ Byte[15] = Data byte 10
 Response: -
 See ComfoAir command list on CC-Ease
 */
-#define CMD_GET_RF_COMMAND 0x39
-#define RES_GET_RF_COMMAND 0x40
+#define CMD_GET_RF_COMMAND 0x39 // todo missing
+#define RES_GET_RF_COMMAND 0x40 // todo missing
 
 // ========================================================
 // ========== Command list (ComfoAir to CC-Ease) ==========
@@ -863,8 +870,8 @@ Byte[4] = Backlight (fixed at 100%)
 
 Response:
 */
-#define CMD_SET_PARAMETER 0x38
-#define RES_SET_PARAMETER []
+#define CMD_SET_PARAMETER 0x38 // todo missing
+#define RES_SET_PARAMETER []   // todo missing
 
 /*
 Data: 10 bytes
@@ -961,8 +968,9 @@ Byte[9] = (1 = on / 0 = off)
 
 Response: -
 */
-#define CMD_SET_DISPLAY 0x39
-#define RES_SET_DISPLAY []
+#define CMD_SET_DISPLAY                                                                                                \
+  0x39                     // todo missing // todo this differs from Protokollbeschreibung_ComfoAir.pdf which says 0x3C
+#define RES_SET_DISPLAY [] // todo missing
 
 /*
 Data: 4 bytes
@@ -973,8 +981,8 @@ Byte[3] = RF Address 1 (High Byte)
 
 Response: -
 */
-#define CMD_SET_RF_ADDRESS 0x3E
-#define RES_SET_RF_ADDRESS []
+#define CMD_SET_RF_ADDRESS 0x3E // todo missing
+#define RES_SET_RF_ADDRESS []   // todo missing
 
 /*
 Data: 21 bytes
@@ -1005,5 +1013,5 @@ Byte[20] = Control bits
 
 Response:
 */
-#define CMD_SEND_RF_COMMAND 0x40
-#define RES_SEND_RF_COMMAND []
+#define CMD_SEND_RF_COMMAND 0x40 // todo missing
+#define RES_SEND_RF_COMMAND []   // todo missing


### PR DESCRIPTION
## Summary

- Merge the five commits currently on `parsley/master` while preserving their history.
- Integrate the fork's framed UART protocol implementation with the fan-level controls, binary filter status, and separate preheating states already on `master`.
- Add ESP32-S3 DevKitC-1 and Wemos D1 Mini32 MQTT/web-server examples, retargeted to this repository.
- Update the ESP8266 example for current ESPHome configuration syntax.
- Document the two-second request interval and roughly 20-second regular polling cycle.

## Integration fixes

- Reject oversized or malformed frames before parsing them.
- Bound version payload copies and prevent zero-period RPM division.
- Escape transmitted checksum bytes and accept both escaped and raw checksum forms on receive for compatibility with existing protocol implementations.
- Preserve Auto fan reporting and prevent level-zero underflow.
- Keep the existing reset method names compatible with older YAML examples.
- Preserve unknown filter and preheating states instead of publishing them as false.

The fork's protocol rewrite did not include the newer entities from PRs #80, #81, and #82, and its frame handling lacked several length and buffer guards. The merge resolution combines both lines of work and adds those guards.

## Validation

- `esphome config comfoair.yaml` with the local component: valid on ESPHome 2026.7.0
- `git diff --check`: passed
- `clang-format`: applied to the changed C/C++ headers
- No repository test suite is present
- PlatformIO build and hardware validation were not run

Draft only for review; this has not been merged into `master`.
