### PR TITLE
Add weekly Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Enable weekly Dependabot version updates for GitHub Actions.
- Group all Action updates into one pull request to reduce notification noise.
- Run checks on Monday at 06:00 Europe/Amsterdam time.

## Scope

This repository currently declares third-party versions only through GitHub Actions references. The Pylint and ESPHome packages are installed inline without a Python dependency manifest, so Dependabot cannot safely update those package versions yet.

## Validation

- Parsed `.github/dependabot.yml` successfully as YAML.
- Confirmed the required Dependabot version and update entries are present.
- `git diff --check` passed.
