### PR TITLE
Run Pylint only for Python changes

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,7 +3,11 @@ name: Pylint
 on:
   push:
     branches: [master]
+    paths:
+      - "**/*.py"
   pull_request:
+    paths:
+      - "**/*.py"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- add `**/*.py` path filters to the Pylint workflow's push and pull-request triggers
- skip the four-job Python matrix when no Python file changed

## Impact

README, YAML, and workflow-only changes no longer start Pylint. Any change containing a Python file still runs the full matrix.

## Validation

- `actionlint .github/workflows/pylint.yml`
- `git diff --check`
- this repository has no test suite
